### PR TITLE
#28 Fix TypeError if listing empty configs

### DIFF
--- a/src/config/cli.js
+++ b/src/config/cli.js
@@ -45,7 +45,7 @@ class CliConfig extends Config {
    * @override
    */
   async contexts () {
-    return Object.keys(this._cliConfig.get(`${this.configKey}`)).filter(this._keyIsContextName)
+    return Object.keys(this._cliConfig.get(`${this.configKey}`) || {}).filter(this._keyIsContextName)
   }
 }
 

--- a/test/config/cli.test.js
+++ b/test/config/cli.test.js
@@ -63,3 +63,12 @@ test('contexts()', async () => {
   await expect(config.contexts()).resolves.toEqual(['sheep', 'cow'])
   expect(aioConfig.get).toHaveBeenCalledWith('imsKey')
 })
+
+test('contexts() (empty)', async () => {
+  const config = new CliConfig('imsKey')
+
+  aioConfig.get.mockReturnValue()
+
+  await expect(config.contexts()).resolves.toEqual([])
+  expect(aioConfig.get).toHaveBeenCalledWith('imsKey')
+})


### PR DESCRIPTION
See #28 

## Description

Just make sure there is an object for the `Objects.keys()` function.

## Related Issue

#28 

## Motivation and Context

See #28

## How Has This Been Tested?

## Screenshots (if appropriate):

n/a

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
