### PR TITLE
Ims.validateToken passes invalid token_type field, causes valid tokens to be rejected

### DIFF
--- a/src/ims.js
+++ b/src/ims.js
@@ -421,7 +421,7 @@ class Ims {
     }
 
     const postData = {
-      token_type: tokenData.type,
+      type: tokenData.type,
       client_id: clientId
     }
 

--- a/test/ims.test.js
+++ b/test/ims.test.js
@@ -156,7 +156,7 @@ test('Ims.validateToken(token, clientId)', async () => {
     uri: expect.stringContaining('/ims/validate_token/v1'),
     form: {
       client_id: 'some-client-id-2',
-      token_type: 'access token'
+      type: 'access token'
     },
     auth: { bearer: token }
   }))
@@ -190,7 +190,7 @@ test('Ims.validateToken(token), extracts client id from token', async () => {
     uri: expect.stringContaining('/ims/validate_token/v1'),
     form: {
       client_id: 'some-client-id',
-      token_type: 'access token'
+      type: 'access token'
     },
     auth: { bearer: token }
   }))


### PR DESCRIPTION
# Description

The bug causes certain JWTs to fail with error: 

```
400 - {"error_description": "Type parameter is required!", "error": "invalid_parameter_value"}
```

It is unclear why some JWTs succeed and some fail. I have 2 integrations in the same IMS organization where 1 succeeds and the other one fails due to the error above. In any case the IMS API specifies that the `token` field is mandatory.  

## Related Issue

https://github.com/adobe/aio-lib-ims/issues/40

## Motivation and Context

Change is required to make sure that all valid JWTs created for I/O Console integrations are validated successfully. 

## How Has This Been Tested?

I have tested it by modifying the shared IMS action validator code to use an `aio-lib-ims` library that contains this fix.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
