### PR TITLE
set cli context to global config and fix merge issues

### DIFF
--- a/api.md
+++ b/api.md
@@ -458,7 +458,7 @@ Sets the cli context data
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | contextData | <code>object</code> |  | the data to save |
-| [local] | <code>boolean</code> | <code>true</code> | set to true to save to local config, false for global config |
+| [local] | <code>boolean</code> | <code>false</code> | set to true to save to local config, false for global config |
 | [merge] | <code>boolean</code> | <code>true</code> | set to true to merge existing data with the new data |
 
 <a name="Context"></a>
@@ -471,7 +471,7 @@ the Adobe I/O Lib IMS Library.
 
 * [Context](#Context)
     * [.getCurrent()](#Context+getCurrent) ⇒ <code>Promise.&lt;string&gt;</code>
-    * [.setCurrent(contextName, [local])](#Context+setCurrent) ⇒ <code>Promise.&lt;any&gt;</code>
+    * [.setCurrent(contextName)](#Context+setCurrent) ⇒ <code>Promise.&lt;any&gt;</code>
     * [.getPlugins()](#Context+getPlugins) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
     * [.setPlugins(plugins)](#Context+setPlugins)
     * [.get(contextName)](#Context+get) ⇒ <code>Promise.&lt;object&gt;</code>
@@ -487,16 +487,15 @@ Gets the current context name.
 **Returns**: <code>Promise.&lt;string&gt;</code> - the current context name  
 <a name="Context+setCurrent"></a>
 
-### context.setCurrent(contextName, [local]) ⇒ <code>Promise.&lt;any&gt;</code>
-Sets the current context name
+### context.setCurrent(contextName) ⇒ <code>Promise.&lt;any&gt;</code>
+Sets the current context name in the local configuration
 
 **Kind**: instance method of [<code>Context</code>](#Context)  
 **Returns**: <code>Promise.&lt;any&gt;</code> - returns an instance of the Config object  
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| contextName | <code>string</code> |  | The name of the context to use as the current context |
-| [local] | <code>boolean</code> | <code>true</code> | Persist the current name in local or global configuration, this is not relevant when running in Adobe I/O Runtime. |
+| Param | Type | Description |
+| --- | --- | --- |
+| contextName | <code>string</code> | The name of the context to use as the current context |
 
 <a name="Context+getPlugins"></a>
 

--- a/src/ctx/ConfigCliContext.js
+++ b/src/ctx/ConfigCliContext.js
@@ -39,10 +39,10 @@ class ConfigCliContext extends Context {
    * Sets the cli context data
    *
    * @param {object} contextData the data to save
-   * @param {boolean} [local=true] set to true to save to local config, false for global config
+   * @param {boolean} [local=false] set to true to save to local config, false for global config
    * @param {boolean} [merge=true] set to true to merge existing data with the new data
    */
-  async setCli (contextData, local = true, merge = true) {
+  async setCli (contextData, local = false, merge = true) {
     debug(`set cli=${JSON.stringify(contextData)} local:${!!local} merge:${!!merge}`)
 
     const dataIsObject = (typeof contextData === 'object' && contextData !== null)

--- a/src/ctx/Context.js
+++ b/src/ctx/Context.js
@@ -32,15 +32,15 @@ class Context {
   }
 
   /**
-   * Sets the current context name
+   * Sets the current context name in the local configuration
    *
    * @param {string} contextName The name of the context to use as the current context
-   * @param {boolean} [local=true] Persist the current name in local or global configuration, this is not relevant when running in Adobe I/O Runtime.
    * @returns {Promise<any>} returns an instance of the Config object
    */
-  async setCurrent (contextName, local = true) {
+  async setCurrent (contextName) {
     debug('set current=%s', contextName)
-    await this.setConfigValue(this.keyNames.CURRENT, contextName, local)
+    // enforce to local config, current should not conflict with global IMS contexts such as `cli`
+    await this.setConfigValue(this.keyNames.CURRENT, contextName, true)
   }
 
   /**

--- a/test/ctx/ConfigCliContext.test.js
+++ b/test/ctx/ConfigCliContext.test.js
@@ -52,14 +52,14 @@ describe('setCli', () => {
     aioConfig.get.mockReturnValue(undefined)
     await expect(context.setCli({ the: 'value' })).resolves.toEqual(undefined)
     expect(aioConfig.get).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`)
-    expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, { the: 'value' }, true)
+    expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, { the: 'value' }, false)
   })
 
   test('{ the: value }, prev={ another: fakevalue }', async () => {
     aioConfig.get.mockReturnValue({ another: 'fakevalue' })
     await expect(context.setCli({ the: 'value' })).resolves.toEqual(undefined)
     expect(aioConfig.get).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`)
-    expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, { the: 'value', another: 'fakevalue' }, true)
+    expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, { the: 'value', another: 'fakevalue' }, false)
   })
 
   test('{ the: value }, local=false, merge=false, prev={ another: fakevalue }', async () => {
@@ -69,11 +69,11 @@ describe('setCli', () => {
     expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, { the: 'value' }, false)
   })
 
-  test('{ the: value }, local=false, merge=true, prev={ another: fakevalue }', async () => {
+  test('{ the: value }, local=true, merge=true, prev={ another: fakevalue }', async () => {
     aioConfig.get.mockReturnValue({ another: 'fakevalue' })
-    await expect(context.setCli({ the: 'value' }, false, true)).resolves.toEqual(undefined)
+    await expect(context.setCli({ the: 'value' }, true, true)).resolves.toEqual(undefined)
     expect(aioConfig.get).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`)
-    expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, { the: 'value', another: 'fakevalue' }, false)
+    expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, { the: 'value', another: 'fakevalue' }, true)
   })
 
   test('{ the: value }, local=false, merge=true, prev={ the: valueold }', async () => {

--- a/test/ctx/ConfigCliContext.test.js
+++ b/test/ctx/ConfigCliContext.test.js
@@ -51,14 +51,14 @@ describe('setCli', () => {
   test('{ the: value }, no previous value', async () => {
     aioConfig.get.mockReturnValue(undefined)
     await expect(context.setCli({ the: 'value' })).resolves.toEqual(undefined)
-    expect(aioConfig.get).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`)
+    expect(aioConfig.get).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, 'global')
     expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, { the: 'value' }, false)
   })
 
   test('{ the: value }, prev={ another: fakevalue }', async () => {
     aioConfig.get.mockReturnValue({ another: 'fakevalue' })
     await expect(context.setCli({ the: 'value' })).resolves.toEqual(undefined)
-    expect(aioConfig.get).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`)
+    expect(aioConfig.get).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, 'global')
     expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, { the: 'value', another: 'fakevalue' }, false)
   })
 
@@ -72,14 +72,14 @@ describe('setCli', () => {
   test('{ the: value }, local=true, merge=true, prev={ another: fakevalue }', async () => {
     aioConfig.get.mockReturnValue({ another: 'fakevalue' })
     await expect(context.setCli({ the: 'value' }, true, true)).resolves.toEqual(undefined)
-    expect(aioConfig.get).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`)
+    expect(aioConfig.get).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, 'local')
     expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, { the: 'value', another: 'fakevalue' }, true)
   })
 
   test('{ the: value }, local=false, merge=true, prev={ the: valueold }', async () => {
     aioConfig.get.mockReturnValue({ the: 'valueold' })
     await expect(context.setCli({ the: 'value' }, false, true)).resolves.toEqual(undefined)
-    expect(aioConfig.get).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`)
+    expect(aioConfig.get).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, 'global')
     expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}.${keyNames.CLI}`, { the: 'value' }, false)
   })
   test('value=notanobject', async () => {

--- a/test/ctx/Context.test.js
+++ b/test/ctx/Context.test.js
@@ -84,12 +84,6 @@ describe('setCurrent', () => {
     expect(ret).toEqual(undefined)
     expect(context.setConfigValue).toHaveBeenCalledWith(keyNames.CURRENT, 'fake', true)
   })
-  test('(fake, false)', async () => {
-    context.setConfigValue = jest.fn().mockResolvedValue('returnValue')
-    const ret = await context.setCurrent('fake', false)
-    expect(ret).toEqual(undefined)
-    expect(context.setConfigValue).toHaveBeenCalledWith(keyNames.CURRENT, 'fake', false)
-  })
 })
 
 describe('get', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This will fix https://github.com/adobe/aio-cli-plugin-auth/issues/48 as now https://github.com/adobe/aio-cli-plugin-auth/blob/master/src/commands/auth/login.js#L38 will only write to global and won't merge the global config to local

Two fundamental changes:
- context.setCurrent will always save to your local config (argument to set local/global removed)
- context.setCli will now save to global by default (was local before)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
