### PR TITLE
Do not set default current context

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ The library supports maintaining multiple configurations for different use cases
 Each such configuration is stored in its own named object with the `ims` configuration.
 Such a configuration is called an _IMS (configuration) context_ and has a label which allows to refer to the configuration by name.
 
-To simplify usage, there may be a designated _current context_ which is always used if explicit context is not given to the command.
-Inside the `ims` configuration object, the name of the _current context_ is stored in the `current` property.
+Inside the `ims` configuration object, the name of the _current context_ is stored in the `config.current` property.
 
 Here is an example `ims` configuration
 

--- a/api.md
+++ b/api.md
@@ -546,8 +546,7 @@ current context name. The result is an object with two properties:
 ### context.set(contextName, contextData, local)
 Updates the named configuration with new configuration data. If a configuration
 object for the named context already exists it is completely replaced with this new
-configuration. If no current contexts are set, then contextName will be set as
-current context.
+configuration.
 
 **Kind**: instance method of [<code>Context</code>](#Context)  
 

--- a/src/ctx/Context.js
+++ b/src/ctx/Context.js
@@ -104,8 +104,7 @@ class Context {
   /**
    * Updates the named configuration with new configuration data. If a configuration
    * object for the named context already exists it is completely replaced with this new
-   * configuration. If no current contexts are set, then contextName will be set as
-   * current context.
+   * configuration.
    *
    * @param {string} contextName Name of the context to update
    * @param {object} contextData The configuration data to store for the context
@@ -126,12 +125,6 @@ class Context {
     }
 
     await this.setContextValue(contextName, contextData, !!local)
-
-    // if there is no current context set, set this one
-    if (!current && !await this.getCurrent()) {
-      debug(`current is not set, setting current to '${contextName}'`, contextName)
-      await this.setCurrent(contextName)
-    }
   }
 
   /**

--- a/test/ctx/Context.test.js
+++ b/test/ctx/Context.test.js
@@ -138,8 +138,7 @@ describe('set', () => {
     const ret = await context.set('fake', { data: 'fake' })
     expect(ret).toEqual(undefined)
     expect(context.setContextValue).toHaveBeenCalledWith('fake', { data: 'fake' }, false)
-    expect(context.getConfigValue).toHaveBeenCalledWith(keyNames.CURRENT)
-    expect(context.setConfigValue).toHaveBeenCalledWith(keyNames.CURRENT, 'fake', true)
+    expect(context.setConfigValue).toHaveBeenCalledTimes(0)
   })
 
   test('(fake, { data: fake }), current=other', async () => {
@@ -149,7 +148,6 @@ describe('set', () => {
     const ret = await context.set('fake', { data: 'fake' })
     expect(ret).toEqual(undefined)
     expect(context.setContextValue).toHaveBeenCalledWith('fake', { data: 'fake' }, false)
-    expect(context.getConfigValue).toHaveBeenCalledWith(keyNames.CURRENT)
     expect(context.setConfigValue).toHaveBeenCalledTimes(0)
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I've noticed that now that we force setCurrent to be local every time the user runs `aio login` there will be a local `.aio` with the current context set.. That's annoying. Also I find it more intuitive to set a current context only if the user requested it

cc @shazron wdyt? 
also before merging this we should make sure it doesn't break anything or we might get this in with other breaking changes (plugins?) if we want to make it a major (even tho it feels more like a bug IMO)?


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
