### PR TITLE
Support for IMS service token generation plugin

### DIFF
--- a/src/token-helper.js
+++ b/src/token-helper.js
@@ -33,11 +33,13 @@ if (!ACTION_BUILD) {
   // use OAuth and CLI imports only when WEBPACK_ACTION_BUILD global is not set
   const imsCliPlugin = require('@adobe/aio-lib-ims-oauth/src/ims-cli')
   const imsOAuthPlugin = require('@adobe/aio-lib-ims-oauth')
+  const imsS2sPlugin = require('@adobe/aio-lib-ims-s2s')
 
   DEFAULT_CREATE_TOKEN_PLUGINS = {
     cli: imsCliPlugin,
     jwt: imsJwtPlugin,
-    oauth: imsOAuthPlugin
+    oauth: imsOAuthPlugin,
+    s2s: imsS2sPlugin
   }
 }
 


### PR DESCRIPTION
Support for IMS service token generation plugin

## Description

Adds `s2s` (service-to-service) plugin to support service token generation. This is currently WIP, see #34 .

## Related Issue

#34 

## Motivation and Context

Currently, the existing `aio-lib-ims` does not provide means to generate IMS service tokens for service-to-service integrations. The proposed change integrates that support via a plugin analogous to the `@adobe/aio-lib-ims-jwt` one.

## How Has This Been Tested?

100% code coverage via unit tests (jest) of the plugin that is being integrated. I've also tested this locally and validated the resulting IMS service token in an API call to a service requiring such a service token.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
