### PR TITLE
feat: add support for stage/prod env switching

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bugs": "https://github.com/adobe/aio-lib-ims/issues",
   "dependencies": {
     "@adobe/aio-lib-core-config": "^2.0.0",
+    "@adobe/aio-lib-env": "^1.0.0",
     "@adobe/aio-lib-ims-jwt": "^2.0.0",
     "@adobe/aio-lib-ims-oauth": "^3.0.0",
     "@adobe/aio-lib-state": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "bugs": "https://github.com/adobe/aio-lib-ims/issues",
   "dependencies": {
     "@adobe/aio-lib-core-config": "^2.0.0",
+    "@adobe/aio-lib-core-logging": "^1.2.0",
     "@adobe/aio-lib-env": "^1.0.0",
     "@adobe/aio-lib-ims-jwt": "^2.0.0",
     "@adobe/aio-lib-ims-oauth": "^3.0.0",
     "@adobe/aio-lib-state": "^1.0.4",
-    "debug": "^4.1.1",
     "lodash.clonedeep": "^4.5.0",
     "request": "^2",
     "request-promise-native": "^1.0.5"

--- a/src/context.js
+++ b/src/context.js
@@ -10,8 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const debug = require('debug')('@adobe/aio-lib-ims/context')
-
+const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-ims:context', { provider: 'debug' })
 const ActionContext = require('./ctx/StateActionContext')
 const CliContext = require('./ctx/ConfigCliContext')
 
@@ -39,10 +38,10 @@ const CURRENT = 'current'
 /** @private */
 function guessContextType () {
   if (process.env.__OW_ACTION_NAME) {
-    debug(`guessing context type: ${TYPE_ACTION}`)
+    aioLogger.debug(`guessing context type: ${TYPE_ACTION}`)
     return TYPE_ACTION
   }
-  debug(`guessing context type: ${TYPE_CLI}`)
+  aioLogger.debug(`guessing context type: ${TYPE_CLI}`)
   return TYPE_CLI
 }
 

--- a/src/ctx/ConfigCliContext.js
+++ b/src/ctx/ConfigCliContext.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const debug = require('debug')('@adobe/aio-lib-ims/ctx/ConfigCliContext')
+const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-ims:ConfigCliContext', { provider: 'debug' })
 const Context = require('./Context')
 
 /**
@@ -31,7 +31,7 @@ class ConfigCliContext extends Context {
    * @returns {Promise<any>} the cli context data
    */
   async getCli () {
-    debug('get cli')
+    aioLogger.debug('get cli')
     return this.getContextValue(this.keyNames.CLI)
   }
 
@@ -43,7 +43,7 @@ class ConfigCliContext extends Context {
    * @param {boolean} [merge=true] set to true to merge existing data with the new data
    */
   async setCli (contextData, local = false, merge = true) {
-    debug(`set cli=${JSON.stringify(contextData)} local:${!!local} merge:${!!merge}`)
+    aioLogger.debug(`set cli=${JSON.stringify(contextData)} local:${!!local} merge:${!!merge}`)
 
     const dataIsObject = (typeof contextData === 'object' && contextData !== null)
     if (!dataIsObject) {
@@ -62,7 +62,7 @@ class ConfigCliContext extends Context {
    * @ignore
    */
   async getContextValue (key) {
-    debug('getContextValue(%s)', key)
+    aioLogger.debug('getContextValue(%s)', key)
     // no source option -> always get it from all sources
     return this.getContextValueFromOptionalSource(key)
   }
@@ -73,7 +73,7 @@ class ConfigCliContext extends Context {
    * @ignore
    */
   async getConfigValue (key) {
-    debug('getConfigValue(%s)', key)
+    aioLogger.debug('getConfigValue(%s)', key)
     return this.aioConfig.get(`${this.keyNames.IMS}.${this.keyNames.CONFIG}.${key}`)
   }
 
@@ -83,7 +83,7 @@ class ConfigCliContext extends Context {
    * @ignore
    */
   async setContextValue (key, value, isLocal) {
-    debug('setContextValue(%s, %o, isLocal=%s)', key, value, isLocal)
+    aioLogger.debug('setContextValue(%s, %o, isLocal=%s)', key, value, isLocal)
     this.aioConfig.set(`${this.keyNames.IMS}.${this.keyNames.CONTEXTS}.${key}`, value, isLocal)
   }
 
@@ -93,7 +93,7 @@ class ConfigCliContext extends Context {
    * @ignore
    */
   async setConfigValue (key, value, isLocal) {
-    debug('setConfigValue(%s, %o, isLocal=%s)', key, value, isLocal)
+    aioLogger.debug('setConfigValue(%s, %o, isLocal=%s)', key, value, isLocal)
     this.aioConfig.set(`${this.keyNames.IMS}.${this.keyNames.CONFIG}.${key}`, value, isLocal)
   }
 

--- a/src/ctx/Context.js
+++ b/src/ctx/Context.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const debug = require('debug')('@adobe/aio-lib-ims/ctx/Context')
+const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-ims:Context', { provider: 'debug' })
 
 /**
  * The `Context` abstract class provides an interface to manage the IMS configuration contexts on behalf of
@@ -27,7 +27,7 @@ class Context {
    * @returns {Promise<string>} the current context name
    */
   async getCurrent () {
-    debug('get current')
+    aioLogger.debug('get current')
     return this.getConfigValue(this.keyNames.CURRENT)
   }
 
@@ -38,7 +38,7 @@ class Context {
    * @returns {Promise<any>} returns an instance of the Config object
    */
   async setCurrent (contextName) {
-    debug('set current=%s', contextName)
+    aioLogger.debug('set current=%s', contextName)
     // enforce to local config, current should not conflict with global IMS contexts such as `cli`
     await this.setConfigValue(this.keyNames.CURRENT, contextName, true)
   }
@@ -55,7 +55,7 @@ class Context {
    * @returns {Promise<object>} The configuration object
    */
   async get (contextName) {
-    debug('get(%s)', contextName)
+    aioLogger.debug('get(%s)', contextName)
 
     if (!contextName) {
       contextName = await this.getCurrent()
@@ -89,7 +89,7 @@ class Context {
    *
    */
   async set (contextName, contextData, local = false) {
-    debug('set(%s, %o)', contextName, contextData, !!local)
+    aioLogger.debug('set(%s, %o)', contextName, contextData, !!local)
 
     let current
     if (!contextName) {
@@ -109,7 +109,7 @@ class Context {
    * @returns {Promise<string[]>} The names of the currently known configurations.
    */
   async keys () {
-    debug('keys()')
+    aioLogger.debug('keys()')
     return this.contextKeys()
   }
 

--- a/src/ctx/StateActionContext.js
+++ b/src/ctx/StateActionContext.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const debug = require('debug')('@adobe/aio-lib-ims/ctx/StateActionContext')
+const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-ims:StateActionContext', { provider: 'debug' })
 const cloneDeep = require('lodash.clonedeep')
 const Context = require('./Context')
 const State = require('@adobe/aio-lib-state')
@@ -54,7 +54,7 @@ class StateActionContext extends Context {
    * @ignore
    */
   async getContextValue (key) {
-    debug('getContextValue(%s)', key)
+    aioLogger.debug('getContextValue(%s)', key)
     // on first run load the tokens from the cloud State
     await this.loadTokensOnce()
     return cloneDeep(this.data[this.keyNames.CONTEXTS][key])
@@ -66,7 +66,7 @@ class StateActionContext extends Context {
    * @ignore
    */
   async getConfigValue (key) {
-    debug('getConfigValue(%s)', key)
+    aioLogger.debug('getConfigValue(%s)', key)
     return cloneDeep(this.data[this.keyNames.CONFIG][key])
   }
 
@@ -76,7 +76,7 @@ class StateActionContext extends Context {
    * @ignore
    */
   async setContextValue (key, value, isLocal) {
-    debug('setContextValue(%s, %o, isLocal=%s)', key, value, isLocal)
+    aioLogger.debug('setContextValue(%s, %o, isLocal=%s)', key, value, isLocal)
 
     if (!isLocal) {
       if (this.hasToken(value)) {
@@ -99,7 +99,7 @@ class StateActionContext extends Context {
    * @ignore
    */
   async setConfigValue (key, value) {
-    debug('setConfigValue(%s, %o, isLocal=true)', key, value)
+    aioLogger.debug('setConfigValue(%s, %o, isLocal=true)', key, value)
     // we only write into local memory for now (no global/cloud config)
     this.data[this.keyNames.CONFIG][key] = cloneDeep(value)
   }

--- a/src/ims.js
+++ b/src/ims.js
@@ -191,15 +191,12 @@ class Ims {
    *
    * @param {string} env The name of the environment. `prod` and `stage`
    *      are the only values supported. `prod` is default and any value
-   *      other than `prod` or `stage` stage is assumed to be the default
+   *      other than `prod` or `stage` it is assumed to be the default
    *      value of `prod`. If not set, it will get the global cli env value. See https://github.com/adobe/aio-lib-env
+   *      (which defaults to `prod` as well if not set)
    */
   constructor (env = getCliEnv()) {
-    if (!env || !IMS_ENDPOINTS[env]) {
-      env = DEFAULT_ENV
-    }
-
-    this.endpoint = IMS_ENDPOINTS[env]
+    this.endpoint = IMS_ENDPOINTS[env] || IMS_ENDPOINTS[DEFAULT_ENV]
   }
 
   /**

--- a/src/ims.js
+++ b/src/ims.js
@@ -13,9 +13,7 @@ governing permissions and limitations under the License.
 const rp = require('request-promise-native')
 const debug = require('debug')('@adobe/aio-cli-ims/ims')
 const url = require('url')
-
-// default IMS environment
-const DEFAULT_ENVIRONMENT = 'prod'
+const { getCliEnv, DEFAULT_ENV } = require('@adobe/aio-lib-env')
 
 const IMS_ENDPOINTS = {
   stage: 'https://ims-na1-stg1.adobelogin.com',
@@ -194,11 +192,11 @@ class Ims {
    * @param {string} env The name of the environment. `prod` and `stage`
    *      are the only values supported. `prod` is default and any value
    *      other than `prod` or `stage` stage is assumed to be the default
-   *      value of `prod`.
+   *      value of `prod`. If not set, it will get the global cli env value. See https://github.com/adobe/aio-lib-env
    */
-  constructor (env) {
+  constructor (env = getCliEnv()) {
     if (!env || !IMS_ENDPOINTS[env]) {
-      env = DEFAULT_ENVIRONMENT
+      env = DEFAULT_ENV
     }
 
     this.endpoint = IMS_ENDPOINTS[env]

--- a/test/ims.test.js
+++ b/test/ims.test.js
@@ -70,6 +70,10 @@ test('constructor', () => {
   ims = new Ims('gibberish')
   expect(ims.endpoint).toEqual(endpoints.PROD_ENV)
 
+  // if constructor parameter is set to null, should use PROD endpoint (default env)
+  ims = new Ims(null)
+  expect(ims.endpoint).toEqual(endpoints.PROD_ENV)
+
   // if global cli env is set to STAGE, should use it
   libEnv.getCliEnv.mockReturnValue(STAGE_ENV)
   ims = new Ims()

--- a/test/ims.test.js
+++ b/test/ims.test.js
@@ -11,6 +11,10 @@ governing permissions and limitations under the License.
 */
 
 const rp = require('request-promise-native')
+const libEnv = require('@adobe/aio-lib-env')
+const { STAGE_ENV, PROD_ENV } = jest.requireActual('@adobe/aio-lib-env')
+
+jest.mock('@adobe/aio-lib-env')
 jest.mock('request-promise-native')
 
 const {
@@ -26,6 +30,7 @@ const {
 
 afterEach(() => {
   jest.restoreAllMocks()
+  libEnv.getCliEnv.mockReturnValue(PROD_ENV) // default
   rp.mockRestore()
 })
 
@@ -44,6 +49,41 @@ test('exports', async () => {
   expect(typeof CLIENT_ID).toEqual('string')
   expect(typeof CLIENT_SECRET).toEqual('string')
   expect(typeof SCOPE).toEqual('string')
+})
+
+test('constructor', () => {
+  const endpoints = {
+    PROD_ENV: 'https://ims-na1.adobelogin.com',
+    STAGE_ENV: 'https://ims-na1-stg1.adobelogin.com'
+  }
+  let ims
+
+  // default, should use PROD endpoint (default for global cli env is PROD)
+  ims = new Ims()
+  expect(ims.endpoint).toEqual(endpoints.PROD_ENV)
+
+  // if constructor parameter is set to STAGE, should use STAGE endpoint (overrides global env)
+  ims = new Ims(STAGE_ENV)
+  expect(ims.endpoint).toEqual(endpoints.STAGE_ENV)
+
+  // if constructor parameter is set to an unknown string, should use PROD endpoint (default env)
+  ims = new Ims('gibberish')
+  expect(ims.endpoint).toEqual(endpoints.PROD_ENV)
+
+  // if global cli env is set to STAGE, should use it
+  libEnv.getCliEnv.mockReturnValue(STAGE_ENV)
+  ims = new Ims()
+  expect(ims.endpoint).toEqual(endpoints.STAGE_ENV)
+
+  // if global cli env is set to PROD, should use it
+  libEnv.getCliEnv.mockReturnValue(PROD_ENV)
+  ims = new Ims()
+  expect(ims.endpoint).toEqual(endpoints.PROD_ENV)
+
+  // default, should use PROD endpoint (global cli env is not set)
+  libEnv.getCliEnv.mockReturnValue(null)
+  ims = new Ims()
+  expect(ims.endpoint).toEqual(endpoints.PROD_ENV)
 })
 
 test('getTokenData', () => {


### PR DESCRIPTION
See also https://github.com/adobe/aio-lib-env
The env key in the constructor for the Ims object will override the global env value set.

Closes #32 as well

## How Has This Been Tested?

npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
