### PR TITLE
#75 Add back configurable access token creation plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Downloads/week](https://img.shields.io/npm/dw/@adobe/aio-lib-ims.svg)](https://npmjs.org/package/@adobe/aio-lib-ims)
 [![Build Status](https://travis-ci.com/adobe/aio-lib-ims.svg?branch=master)](https://travis-ci.com/adobe/aio-lib-ims)
 [![License](https://img.shields.io/npm/l/@adobe/aio-lib-ims.svg)](https://github.com/adobe/aio-lib-ims/blob/master/package.json)
-[![Codecov Coverage](https://img.shields.io/codecov/c/github/adobe/aio-lib-ims/master.svg?style=flat-square)](https://codecov.io/gh/adobe/aio-lib-ims/) 
+[![Codecov Coverage](https://img.shields.io/codecov/c/github/adobe/aio-lib-ims/master.svg?style=flat-square)](https://codecov.io/gh/adobe/aio-lib-ims/)
 
 
 # Adobe I/O IMS Library
@@ -126,7 +126,7 @@ In general, you do not need to deal with this property.
 
 ## Set Current Context (Advanced)
 
-The default context can be set locally with `await context.setCurrent('contextname')`. 
+The default context can be set locally with `await context.setCurrent('contextname')`.
 This will write the following configuration to the `ims` key in the `.aio` file of the current working directory:
 
 ```js
@@ -166,7 +166,7 @@ JWT (service to service integration) configuration requires the following proper
 
 ## Setting the Private Key
 
-For a JWT configuration, your private key is generated in Adobe I/O Console, and is downloaded to your computer when you generate it. 
+For a JWT configuration, your private key is generated in Adobe I/O Console, and is downloaded to your computer when you generate it.
 
 Adobe I/O Console does not keep the private key (only your corresponding public key) so you will have to set the private key that was downloaded manually in your IMS context configuration.
 
@@ -196,6 +196,31 @@ OAuth2 configuration requires the following properties:
 | client_secret | The IMS (OAUth2) Client Secret |
 | redirect_uri | The _Default redirect URI_ from the integration overview screen in the I/O Console. Alternatively, any URI matching one of the _Redirect URI patterns_ may be used. |
 | scope | Scopes to assign to the tokens. This is a string of space separated scope names which depends on the services this integration is subscribed to. Adobe I/O Console does not currently expose the list of scopes defined for OAuth2 integrations, a good list of scopes by service can be found in [OAuth 2.0 Scopes](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/OAuth/Scopes.md). At the very least you may want to enter `openid`. |
+
+
+## Token Creation Plugins
+
+Additional token creation plugins can be registered with the Adobe I/O IMS library configuration.
+Such token creation plugins must comply with the following contract:
+
+* Implemented as a JavaScript module which can be `require()`-ed by the IMS library
+* Registered with the module path used by the `require()` function
+* Implementing 3 functions as follows:
+  * `Promise<any> canSupport(config)` -- Receives the configuration properties of the selected context and returns a promise as to whether the token creation plugin can be used with this configuration. The promise must resolve to `true` if supported or be rejected with an `Error` explaining why the configuration is not supported by the plugin.
+  * `boolean supports(config)` -- Receives the configuration properties of the selected context and returns `true` if supported or `false` if not supported. This is a syncronous function.
+  * `Promise<any> imsLogin(ims, config)` -- Receives an instance of the IMS token manager class and the configuration properties of the selected context to create an access token from. If the token creation plugin does not support the configuration or if an error occurs creating the token, the function must return a `Promise` rejecting with an `Error` explaining the problem. Otherwise the promise should resolve to an `object` containing the access token and optionally a refresh token.
+
+The `Context` class offers two methods to manage token creation plugins:
+
+* `Context.getPlugins()` returning a `Promise<string[]>` listing the additional token creation plugins.
+* `Context.setPlugins(string[])` taking the list of additional token creation plugins to configure.
+
+**Note 1**: the `setPlugins` method completely replaces the current list of plugins.
+Any selective addition of removal must be done in a three step process: Get the plugins, update the list, set the plugins.
+
+**Note 2**: The token creation plugins supporting [JWT](https://github.com/adobe/aio-lib-ims-jwt/blob/master/src/ims-jwt.js), [OAuth2](https://github.com/adobe/aio-lib-ims-oauth/blob/master/src/ims-oauth.js), and [CLI](https://github.com/adobe/aio-lib-ims-oauth/blob/master/src/ims-cli.js) login, are always present.
+As such they are note returned by the `getPlugins` method and should not be provided in the `setPlugins` method.
+
 
 # Contributing
 Contributions are welcomed! Read the [Contributing Guide](CONTRIBUTING.md) for more information.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "stdout-stderr": "^0.1.9"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "files": [
     "/src"

--- a/src/context.js
+++ b/src/context.js
@@ -35,6 +35,9 @@ const CLI = 'cli'
 /** Property holding the current context name */
 const CURRENT = 'current'
 
+/** Property holding the list of additional plugins */
+const PLUGINS = 'plugins'
+
 /** @private */
 function guessContextType () {
   if (process.env.__OW_ACTION_NAME) {
@@ -52,7 +55,7 @@ function getContext () {
     if (guessContextType() === TYPE_ACTION) {
       context = new ActionContext({ IMS, CONTEXTS, CONFIG, CURRENT })
     } else {
-      context = new CliContext({ IMS, CONTEXTS, CONFIG, CURRENT, CLI })
+      context = new CliContext({ IMS, CONTEXTS, CONFIG, CURRENT, CLI, PLUGINS })
     }
   }
   return context
@@ -72,5 +75,6 @@ module.exports = {
   CURRENT,
   CLI,
   CONTEXTS,
-  CONFIG
+  CONFIG,
+  PLUGINS
 }

--- a/src/context.js
+++ b/src/context.js
@@ -35,7 +35,7 @@ const CLI = 'cli'
 /** Property holding the current context name */
 const CURRENT = 'current'
 
-/** Property holding the list of additional plugins */
+/** Property holding the list of additional token creation plugins */
 const PLUGINS = 'plugins'
 
 /** @private */

--- a/src/ctx/ConfigCliContext.js
+++ b/src/ctx/ConfigCliContext.js
@@ -131,15 +131,6 @@ class ConfigCliContext extends Context {
     return Object.keys(this.aioConfig.get(`${this.keyNames.IMS}.${this.keyNames.CONTEXTS}`) || {})
   }
 
-  /**
-   * @protected
-   * @override
-   * @ignore
-   */
-  async plugins () {
-    return this.getConfigValue(this.keyNames.PLUGINS)
-  }
-
   /** @private */
   getContextValueFromOptionalSource (key, source) {
     const fullKey = `${this.keyNames.IMS}.${this.keyNames.CONTEXTS}.${key}`

--- a/src/ctx/ConfigCliContext.js
+++ b/src/ctx/ConfigCliContext.js
@@ -57,6 +57,31 @@ class ConfigCliContext extends Context {
   }
 
   /**
+   * Override super class implementation to prevent return the
+   * plugins if configured at all
+   *
+   * @override
+   */
+  async getPlugins () {
+    aioLogger.debug('getPlugins()')
+    return this.getConfigValue(this.keyNames.PLUGINS) || []
+  }
+
+  /**
+   * Override super class implementation to prevent return the
+   * plugins if configured at all
+   *
+   * @override
+   */
+  async setPlugins (plugins, local = false) {
+    aioLogger.debug('setPlugins(%o, %s)', plugins, !!local)
+
+    if (plugins instanceof Array || plugins === null) {
+      this.setConfigValue(this.keyNames.PLUGINS, plugins, !!local)
+    }
+  }
+
+  /**
    * @protected
    * @override
    * @ignore
@@ -104,6 +129,15 @@ class ConfigCliContext extends Context {
    */
   async contextKeys () {
     return Object.keys(this.aioConfig.get(`${this.keyNames.IMS}.${this.keyNames.CONTEXTS}`) || {})
+  }
+
+  /**
+   * @protected
+   * @override
+   * @ignore
+   */
+  async plugins () {
+    return this.getConfigValue(this.keyNames.PLUGINS)
   }
 
   /** @private */

--- a/src/ctx/ConfigCliContext.js
+++ b/src/ctx/ConfigCliContext.js
@@ -64,7 +64,7 @@ class ConfigCliContext extends Context {
    */
   async getPlugins () {
     aioLogger.debug('getPlugins()')
-    return this.getConfigValue(this.keyNames.PLUGINS) || []
+    return this.getConfigValue(this.keyNames.PLUGINS)
   }
 
   /**

--- a/src/ctx/ConfigCliContext.js
+++ b/src/ctx/ConfigCliContext.js
@@ -57,8 +57,8 @@ class ConfigCliContext extends Context {
   }
 
   /**
-   * Override super class implementation to prevent return the
-   * plugins if configured at all
+   * Override super class implementation to return the plugins configured
+   * in the `plugins` configuration property.
    *
    * @override
    */
@@ -68,8 +68,11 @@ class ConfigCliContext extends Context {
   }
 
   /**
-   * Override super class implementation to prevent return the
-   * plugins if configured at all
+   * Override super class implementation to persist the provided plugins
+   * in the `plugins` configuration property.
+   *
+   * This implementation silently ignores a `plugins` parameter which is
+   * neither and array nor `null`.
    *
    * @override
    */
@@ -78,6 +81,8 @@ class ConfigCliContext extends Context {
 
     if (plugins instanceof Array || plugins === null) {
       this.setConfigValue(this.keyNames.PLUGINS, plugins, !!local)
+    } else {
+      aioLogger.debug('  > Ignoring unexpected plugins parameter \'%o\'', plugins)
     }
   }
 

--- a/src/ctx/Context.js
+++ b/src/ctx/Context.js
@@ -113,6 +113,42 @@ class Context {
     return this.contextKeys()
   }
 
+  /**
+   * Gets the list of configured token creation plugins. This base
+   * implementation returns an empty array. Extensions supporting
+   * token creation plugins must override to return the list of
+   * plugins which can be require-d.
+   *
+   * @returns {Promise<string[]>} the token creation plugins
+   */
+  async getPlugins () {
+    aioLogger.debug('getPlugins() (none)')
+    return []
+  }
+
+  /**
+   * Sets the list of configured token creation plugins. This base
+   * implementation throws an Error as plugins are not support.
+   * Extensions supporting token creation plugins must override to
+   * return check and persist the list of plugins which can be
+   * require-d.
+   *
+   * If the plugins parameter is an empty array or null, the current
+   * plugins configuration is removed. Otherwise the current
+   * configuration is replaced by the new list of plugins.
+   *
+   * Note, that implementations are only required to validate that
+   * the plugins parameter is a possibly empty array of strings or
+   * null. Actually provided string values need not be validated.
+   *
+   * @param {string[]} plugins An array of plugins to configure
+   * @param {boolean} [local=false] set to true to save to local config, false for global config
+   */
+  async setPlugins (plugins, local = false) {
+    aioLogger.debug('setPlugins(%o, %b)', plugins, !!local)
+    throwNotImplemented()
+  }
+
   /* To be implemented */
 
   /**
@@ -165,6 +201,15 @@ class Context {
    */
   async contextKeys () {
     throwNotImplemented()
+  }
+
+  /**
+   * @ignore
+   * @protected
+   * @returns {Promise<string[]>} return plugins, empty by default
+   */
+  async plugins () {
+    return []
   }
 }
 

--- a/src/ctx/Context.js
+++ b/src/ctx/Context.js
@@ -202,15 +202,6 @@ class Context {
   async contextKeys () {
     throwNotImplemented()
   }
-
-  /**
-   * @ignore
-   * @protected
-   * @returns {Promise<string[]>} return plugins, empty by default
-   */
-  async plugins () {
-    return []
-  }
 }
 
 /** @private */

--- a/src/ctx/Context.js
+++ b/src/ctx/Context.js
@@ -119,7 +119,7 @@ class Context {
    * token creation plugins must override to return the list of
    * plugins which can be require-d.
    *
-   * @returns {Promise<string[]>} the token creation plugins
+   * @returns {Promise<string[]>} empty list of token creation plugins
    */
   async getPlugins () {
     aioLogger.debug('getPlugins() (none)')
@@ -128,10 +128,9 @@ class Context {
 
   /**
    * Sets the list of configured token creation plugins. This base
-   * implementation throws an Error as plugins are not support.
+   * implementation throws an Error as plugins are not supported.
    * Extensions supporting token creation plugins must override to
-   * return check and persist the list of plugins which can be
-   * require-d.
+   * check and persist the list of plugins which can be require-d.
    *
    * If the plugins parameter is an empty array or null, the current
    * plugins configuration is removed. Otherwise the current

--- a/src/token-helper.js
+++ b/src/token-helper.js
@@ -50,8 +50,11 @@ async function getMergedPlugins (context) {
         aioLogger.debug("  > adding configured plugins: %o", plugins)
         const configPluginMap = Object.fromEntries(plugins.map(element => [element, element]))
         return Object.assign(configPluginMap, DEFAULT_CREATE_TOKEN_PLUGINS)
+      } else if (plugins !== undefined) {
+        aioLogger.debug('Ignored configured plugins: Expected string[], got: \'%o\'', plugins)
       }
 
+      aioLogger.debug('  > using default plugins only')
       return DEFAULT_CREATE_TOKEN_PLUGINS
     }
   )

--- a/test/ctx/ConfigCliContext.test.js
+++ b/test/ctx/ConfigCliContext.test.js
@@ -20,7 +20,8 @@ const keyNames = {
   CONFIG: 'b',
   CONTEXTS: 'c',
   CURRENT: 'd',
-  CLI: 'd'
+  CLI: 'd',
+  PLUGINS: 'e'
 }
 
 let context
@@ -125,5 +126,59 @@ describe('contextKeys', () => {
     aioConfig.get.mockReturnValue({ the: 'a', dude: 'b', ethan: 'coen', joel: 'coen' })
     await expect(context.contextKeys()).resolves.toEqual(['the', 'dude', 'ethan', 'joel'])
     expect(aioConfig.get).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONTEXTS}`)
+  })
+})
+
+describe('getPlugins', () => {
+  test('(<no args>), plugins=undefined', async () => {
+    context.getConfigValue = jest.fn().mockResolvedValue(undefined)
+    const ret = await context.getPlugins()
+    expect(ret).toEqual(undefined)
+    expect(context.getConfigValue).toHaveBeenCalledWith(keyNames.PLUGINS)
+  })
+  test('(<no args>), plugins=[]', async () => {
+    context.getConfigValue = jest.fn().mockResolvedValue([])
+    const ret = await context.getPlugins()
+    expect(ret).toEqual([])
+    expect(context.getConfigValue).toHaveBeenCalledWith(keyNames.PLUGINS)
+  })
+  test('(<no args>), plugins=45', async () => {
+    context.getConfigValue = jest.fn().mockResolvedValue(45)
+    const ret = await context.getPlugins()
+    expect(ret).toEqual(45)
+    expect(context.getConfigValue).toHaveBeenCalledWith(keyNames.PLUGINS)
+  })
+  test('(<no args>), plugins=[\'@adobe/internal_plugin\']', async () => {
+    context.getConfigValue = jest.fn().mockResolvedValue(['@adobe/internal_plugin'])
+    const ret = await context.getPlugins()
+    expect(ret).toEqual(['@adobe/internal_plugin'])
+    expect(context.getConfigValue).toHaveBeenCalledWith(keyNames.PLUGINS)
+  })
+})
+
+describe('setPlugins', () => {
+  test('(undefined, false)', async () => {
+    await expect(context.setPlugins()).resolves.toEqual(undefined)
+    expect(aioConfig.set).toHaveBeenCalledTimes(0)
+  })
+  test('([], false)', async () => {
+    await expect(context.setPlugins([])).resolves.toEqual(undefined)
+    expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONFIG}.${keyNames.PLUGINS}`, [], false)
+  })
+  test('([\'@adobe/internal_plugin\'], false)', async () => {
+    await expect(context.setPlugins(['@adobe/internal_plugin'])).resolves.toEqual(undefined)
+    expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONFIG}.${keyNames.PLUGINS}`, ['@adobe/internal_plugin'], false)
+  })
+  test('(undefined, true)', async () => {
+    await expect(context.setPlugins(undefined, true)).resolves.toEqual(undefined)
+    expect(aioConfig.set).toHaveBeenCalledTimes(0)
+  })
+  test('([], true)', async () => {
+    await expect(context.setPlugins([], true)).resolves.toEqual(undefined)
+    expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONFIG}.${keyNames.PLUGINS}`, [], true)
+  })
+  test('([\'@adobe/internal_plugin\'], true)', async () => {
+    await expect(context.setPlugins(['@adobe/internal_plugin'], true)).resolves.toEqual(undefined)
+    expect(aioConfig.set).toHaveBeenCalledWith(`${keyNames.IMS}.${keyNames.CONFIG}.${keyNames.PLUGINS}`, ['@adobe/internal_plugin'], true)
   })
 })

--- a/test/ctx/Context.test.js
+++ b/test/ctx/Context.test.js
@@ -47,6 +47,9 @@ describe('not implemented methods', () => {
   test('Context.contextKeys', async () => {
     await expect(context.contextKeys('key', 'value')).rejects.toThrow('abstract method is not implemented')
   })
+  test('Context.setPlugins', async () => {
+    await expect(context.setPlugins(['plugin'])).rejects.toThrow('abstract method is not implemented')
+  })
 })
 
 describe('getCurrent', () => {
@@ -139,5 +142,12 @@ describe('keys', () => {
     const ret = await context.keys()
     expect(ret).toEqual(['fake', 'other'])
     expect(context.contextKeys).toHaveBeenCalledWith()
+  })
+})
+
+describe('getPlugins', () => {
+  test('(<no args>)', async () => {
+    const ret = await context.getPlugins()
+    expect(ret).toEqual([])
   })
 })

--- a/test/token-helper.test.js
+++ b/test/token-helper.test.js
@@ -63,7 +63,7 @@ afterEach(() => {
 })
 
 /** @private */
-function createHandlerForContext (context = {}) {
+function createHandlerForContext (context = {}, withPlugin) {
   const mappedContext = Object.keys(context)
     // prefix ims. to all the keys
     .map(key => {
@@ -75,6 +75,14 @@ function createHandlerForContext (context = {}) {
     .reduce((acc, cur) => {
       return Object.assign(acc, cur)
     }, {})
+
+  // add unresolvable plugin or illegale configuration value depending
+  // on withPlugin parameter (default is unsupported value)
+  if (withPlugin) {
+    mappedContext['ims.config.plugins'] = ['@adobe/__non_existing_login_plugin__']
+  } else {
+    mappedContext['ims.config.plugins'] = '__unsupported_value__'
+  }
 
   const store = {
     ...mappedContext
@@ -139,7 +147,7 @@ test('getToken - string (oauth)', async () => {
 
   setImsPluginMock('oauth', 'abc123')
   config.get.mockImplementation(
-    createHandlerForContext(context)
+    createHandlerForContext(context, true)
   )
 
   // no force
@@ -229,7 +237,7 @@ test('getToken - object (refresh token expired, coverage)', async () => {
 
   setImsPluginMock('jwt', result)
   config.get.mockImplementation(
-    createHandlerForContext(context)
+    createHandlerForContext(context, true)
   )
 
   // no force


### PR DESCRIPTION
## Description

Implementing the feature proposal of issue #75:

* Two methods `setPlugins` and `getPlugins` added to the `Context` class
* Overwriting implementation in the `ConfigCliContext` class using the `plugins` configuration property for pesistence
* `StateActionContext` does not overwrite these methods as configurable token creation plugins are not part of this proposal. They might be added in the future.
* Updated `token-helper.js` to support configurable plugins:
  * Merge default plugins with configurable plugins
  * Lazy load all plugins only as required (also applied to the default plugins for consistency and marginal performance improvement)

## Related Issue

#75 Add back configurable access token creation plugin support

## Motivation and Context

I have use cases for different ways of creation access tokens beyond what the default plugins offer. Having configurable token creation plugins solves my needs for easy extensibility.

## How Has This Been Tested?

Added test cases and tested with my own token creation plugins.

## Screenshots (if appropriate):

n/a

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
