### PR TITLE
Fix token validation error when token expiry set as env

### DIFF
--- a/src/token-helper.js
+++ b/src/token-helper.js
@@ -183,9 +183,12 @@ const IMS_TOKEN_MANAGER = {
   async getTokenIfValid (token) {
     aioLogger.debug('getTokenIfValid(token=%o)', token)
     const minExpiry = Date.now() + 10 * 60 * 1000 // 10 minutes from now
-    if (token && typeof (token.expiry) === 'number' && token.expiry > minExpiry && typeof (token.token) === 'string') {
-      aioLogger.debug('  => %o', token.token)
-      return token.token
+    if (token && token.expiry) {
+      const tokenExpiry = Number(token.expiry)
+      if (typeof (tokenExpiry) === 'number' && tokenExpiry > minExpiry && typeof (token.token) === 'string') {
+        aioLogger.debug('  => %o', token.token)
+        return token.token
+      }
     }
 
     return Promise.reject(new Error('Token missing or expired'))

--- a/test/token-helper.test.js
+++ b/test/token-helper.test.js
@@ -100,7 +100,7 @@ test('getTokenIfValid', async () => {
   }
   await expect(IMS_TOKEN_MANAGER.getTokenIfValid(token)).resolves.toEqual(token.token)
 
-  //expiry as string
+  // expiry as string
   token = {
     token: 'abcdefghijklmnop',
     expiry: (Date.now() + 20 * 60 * 1000).toString()

--- a/test/token-helper.test.js
+++ b/test/token-helper.test.js
@@ -94,9 +94,16 @@ test('getTokenIfValid', async () => {
   await expect(IMS_TOKEN_MANAGER.getTokenIfValid({})).rejects.toEqual(new Error('Token missing or expired'))
 
   // valid token
-  const token = {
+  let token = {
     token: 'abcdefghijklmnop',
     expiry: Date.now() + 20 * 60 * 1000 // 20 minutes from now
+  }
+  await expect(IMS_TOKEN_MANAGER.getTokenIfValid(token)).resolves.toEqual(token.token)
+
+  //expiry as string
+  token = {
+    token: 'abcdefghijklmnop',
+    expiry: (Date.now() + 20 * 60 * 1000).toString()
   }
   await expect(IMS_TOKEN_MANAGER.getTokenIfValid(token)).resolves.toEqual(token.token)
 })


### PR DESCRIPTION
Helps in fixing - [https://github.com/adobe/aio-apps-action/issues/10](https://github.com/adobe/aio-apps-action/issues/10)
When token and its expiry are set as env var, expiry is not set as number but string. This fails the token validation triggering new login.
Made changes to handle such cases as the expiry for such cases is not set as number but string.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
unit tests and manual test
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
