### PR TITLE
fix: add new e2e test to check for expired signed jwt token

### DIFF
--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -50,6 +50,23 @@ test('getAccessToken', async () => {
   await expect(result).rejects.toThrow('400') // 400 access_denied
 })
 
+test('valid and non-expired signed jwt', () => {
+  const [, encodedPayload] = IMS_SIGNED_JWT.split('.', 3)
+  const payload = JSON.parse(Buffer.from(encodedPayload, 'base64'))
+
+  expect(payload.exp).toBeDefined()
+  expect(payload.iss).toBeDefined()
+  expect(payload.sub).toBeDefined()
+  expect(payload.aud).toBeDefined()
+  expect(payload.iat).toBeDefined()
+
+  const expiryDate = new Date(payload.exp * 1000).getTime()
+  const now = Date.now()
+  const isExpired = (expiryDate - now) <= 0
+
+  expect(isExpired).not.toEqual(true)
+})
+
 test('exchangeJwtToken', () => {
   const result = gImsObj.exchangeJwtToken(IMS_CLIENT_ID, IMS_CLIENT_SECRET, IMS_SIGNED_JWT)
   expect(result).toBeDefined()


### PR DESCRIPTION
## Motivation and Context

This is for the daily e2e tests in the `adobe/aio-e2e-tests` repo and will help with debugging.

## How Has This Been Tested?

`npm run e2e`  (with an expired, and non-expired signed jwt)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
