### PR TITLE
feat: ACNA-1854 - add getAccessTokenByClientCredentials function

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install @adobe/aio-lib-ims --save
 
 ## Quickstart
 
-Before using the AIO IMS Library you need to create an integration on Adobe I/O Console from where you can the grab the integration details to setup a first configuration context. Let's use an OAuth2 integration as an example:
+Before using the AIO IMS Library you need to create an integration on Adobe Developer Console from where you can the grab the integration details to setup a first configuration context. Let's use an OAuth2 integration as an example:
 
 ```js
 const { context, getToken, getTokenData } = require('@adobe/aio-lib-ims')
@@ -147,25 +147,27 @@ const token = await getToken() // generate a token for the config in the 'contex
 This will break `aio` commands that run from the same directory.**
 You can revert to the original behaviour by executing `aio config delete ims.config.current` from that directory.
 
-## JWT Configuration
+## JWT Configuration (Deprecated)
+
+The JWT configuration has been deprecated in favor of the OAuth Server-to-Server Configuration.
 
 JWT (service to service integration) configuration requires the following properties:
 
 | Property | Description |
 |--|--|
-| client_id | The IMS (Oauth2) Client ID. This is the _API Key_ in the integration overview of the Adobe I/O Console. |
+| client_id | The IMS (Oauth2) Client ID. This is the _API Key_ in the integration overview of the Adobe Developer Console. |
 | client_secret | The IMS (OAUth2) Client Secret |
-| technical_account_id | The _Technical Account ID_ from the integration overview screen in the I/O Console
-| meta_scopes | An array of meta scope names. These are the labels of one ore more special properties in the sample _JWT payload_. They can be found in the _JWT_ tab of the I/O Console integration in the _JWT payload_ properties of the form `"https://<ims-host>/s/ent_dataservices_sdk": true,`. There may be one or more of depending on the services to which the integration is subscribed. The values to list in the **meta_scopes** property are the last segment of the URL. In the example case, this would be `ent_dataservices_sdk`.
-| ims_org_id | The _Organization ID_ from the integration overview screen in the I/O Console. |
+| technical_account_id | The _Technical Account ID_ from the integration overview screen in the Adobe Developer Console
+| meta_scopes | An array of meta scope names. These are the labels of one ore more special properties in the sample _JWT payload_. They can be found in the _JWT_ tab of the Adobe Developer Console integration in the _JWT payload_ properties of the form `"https://<ims-host>/s/ent_dataservices_sdk": true,`. There may be one or more of depending on the services to which the integration is subscribed. The values to list in the **meta_scopes** property are the last segment of the URL. In the example case, this would be `ent_dataservices_sdk`.
+| ims_org_id | The _Organization ID_ from the integration overview screen in the Adobe Developer Console. |
 | private_key | The private key matching any one of the _Public Keys_ of the integration. This can be the private key all in one line as a string, or an array of strings (each element is a line from the key file) See the [Setting the Private Key](#setting-the-private-key) section. |
 | passphrase | (_Optional_). The passphrase of the private key. |
 
-## Setting the Private Key
+### Setting the Private Key
 
-For a JWT configuration, your private key is generated in Adobe I/O Console, and is downloaded to your computer when you generate it.
+For a JWT configuration, your private key is generated in Adobe Developer Console, and is downloaded to your computer when you generate it.
 
-Adobe I/O Console does not keep the private key (only your corresponding public key) so you will have to set the private key that was downloaded manually in your IMS context configuration.
+Adobe Developer Console does not keep the private key (only your corresponding public key) so you will have to set the private key that was downloaded manually in your IMS context configuration.
 
 You can set your private key in the config via two ways:
 
@@ -187,10 +189,23 @@ OAuth2 configuration requires the following properties:
 
 | Property | Description |
 |--|--|
-| client_id | The IMS (Oauth2) Client ID. This is the _API Key_ in the integration overview of the Adobe I/O Console. |
+| client_id | The IMS (Oauth2) Client ID. This is the _API Key_ in the integration overview of the Adobe Developer Console. |
 | client_secret | The IMS (OAUth2) Client Secret |
-| redirect_uri | The _Default redirect URI_ from the integration overview screen in the I/O Console. Alternatively, any URI matching one of the _Redirect URI patterns_ may be used. |
-| scope | Scopes to assign to the tokens. This is a string of space separated scope names which depends on the services this integration is subscribed to. Adobe I/O Console does not currently expose the list of scopes defined for OAuth2 integrations, a good list of scopes by service can be found in [OAuth 2.0 Scopes](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/OAuth/Scopes.md). At the very least you may want to enter `openid`. |
+| redirect_uri | The _Default redirect URI_ from the integration overview screen in the Adobe Developer Console. Alternatively, any URI matching one of the _Redirect URI patterns_ may be used. |
+| scope | Scopes to assign to the tokens. This is a string of comma separated scope names which depends on the services this integration is subscribed to. Adobe Developer Console does not currently expose the list of scopes defined for OAuth2 integrations, a good list of scopes by service can be found in [OAuth 2.0 Scopes](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/OAuth/Scopes.md). At the very least you may want to enter `openid`. |
+
+## OAuth Server-to-Server Configuration
+
+This configuration is to replace the JWT Configuration.
+
+OAuth Server-to-Server (client credentials grant type) configuration requires the following properties:
+
+| Property | Description |
+|--|--|
+| client_id | The IMS (Oauth2) Client ID. This is the _API Key_ in the integration overview of the Adobe Developer Console. |
+| client_secret | The IMS (OAUth2) Client Secret |
+| org_id | The _Organization ID_ from the integration overview screen in the Adobe Developer Console. |
+| scope | Scopes to assign to the tokens. This is a string of comma separated scope names which depends on the services this integration is subscribed to. The list of scopes defined for the OAuth2 Server-to-Server credential is listed under the `Scopes` tab for the credential in Adobe Developer Console. |
 
 ## Token Validation
 

--- a/README.md
+++ b/README.md
@@ -203,9 +203,9 @@ OAuth Server-to-Server (client credentials grant type) configuration requires th
 | Property | Description |
 |--|--|
 | client_id | The IMS (Oauth2) Client ID. This is the _API Key_ in the integration overview of the Adobe Developer Console. |
-| client_secret | The IMS (OAUth2) Client Secret |
+| client_secrets | An array of IMS (OAUth2) client secrets |
 | org_id | The _Organization ID_ from the integration overview screen in the Adobe Developer Console. |
-| scope | Scopes to assign to the tokens. This is a string of comma separated scope names which depends on the services this integration is subscribed to. The list of scopes defined for the OAuth2 Server-to-Server credential is listed under the `Scopes` tab for the credential in Adobe Developer Console. |
+| scopes | Scopes to assign to the tokens. This is a string of comma separated scope names which depends on the services this integration is subscribed to. The list of scopes defined for the OAuth2 Server-to-Server credential is listed under the `Scopes` tab for the credential in Adobe Developer Console. |
 
 ## Token Validation
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,24 @@
+# Adobe I/O IMS Library
+
 [![Version](https://img.shields.io/npm/v/@adobe/aio-lib-ims.svg)](https://npmjs.org/package/@adobe/aio-lib-ims)
 [![Downloads/week](https://img.shields.io/npm/dw/@adobe/aio-lib-ims.svg)](https://npmjs.org/package/@adobe/aio-lib-ims)
 [![Node.js CI](https://github.com/adobe/aio-lib-ims/actions/workflows/node.js.yml/badge.svg)](https://github.com/adobe/aio-lib-ims/actions/workflows/node.js.yml)[![License](https://img.shields.io/npm/l/@adobe/aio-lib-ims.svg)](https://github.com/adobe/aio-lib-ims/blob/master/package.json)
-[![Codecov Coverage](https://img.shields.io/codecov/c/github/adobe/aio-lib-ims/master.svg?style=flat-square)](https://codecov.io/gh/adobe/aio-lib-ims/) 
-
-
-# Adobe I/O IMS Library
+[![Codecov Coverage](https://img.shields.io/codecov/c/github/adobe/aio-lib-ims/master.svg?style=flat-square)](https://codecov.io/gh/adobe/aio-lib-ims/)
 
 The Adobe I/O IMS Library helps interacting with the IMS API as well as creating and invalidating tokens.
 To support multiple use cases and environments, there is not a single configuration managed by this library but multiple configurations called _IMS configuration contexts_.
 Each configuration context holds configuration data needed to create tokens.
 See the _Configuration_ section below.
 
-# Installation
+## Installation
 
-To install the Adobe I/O IMS Library, simple use `npm`:
+To install the Adobe I/O IMS Library, simply use `npm`:
 
 ```sh
-$ npm install @adobe/aio-lib-ims --save
+npm install @adobe/aio-lib-ims --save
 ```
 
-# Quickstart
+## Quickstart
 
 Before using the AIO IMS Library you need to create an integration on Adobe I/O Console from where you can the grab the integration details to setup a first configuration context. Let's use an OAuth2 integration as an example:
 
@@ -40,7 +39,7 @@ const tokenDecoded = getTokenData(token)
 
 See the [API Documentation](api.md) for full details.
 
-# Configuration
+## Configuration
 
 The AIO IMS Library transparently maintains the login configuration and keep
 access and refresh tokens for reuse before they expire.
@@ -125,7 +124,7 @@ In general, you do not need to deal with this property.
 
 ## Set Current Context (Advanced)
 
-The default context can be set locally with `await context.setCurrent('contextname')`. 
+The default context can be set locally with `await context.setCurrent('contextname')`.
 This will write the following configuration to the `ims` key in the `.aio` file of the current working directory:
 
 ```js
@@ -157,30 +156,27 @@ JWT (service to service integration) configuration requires the following proper
 | client_id | The IMS (Oauth2) Client ID. This is the _API Key_ in the integration overview of the Adobe I/O Console. |
 | client_secret | The IMS (OAUth2) Client Secret |
 | technical_account_id | The _Technical Account ID_ from the integration overview screen in the I/O Console
-| meta_scopes | An array of meta scope names. These are the labels of one ore more special properties in the sample _JWT payload_. They can be found in the _JWT_ tab of the I/O Console integration in the _JWT payload_ properties of the form `"https://<ims-host>/s/ent_dataservices_sdk": true,`. There may be one or more of depending on the services to which the integration is subscribed. The values to list in the *meta_scopes* property are the last segment of the URL. In the example case, this would be `ent_dataservices_sdk`. |
+| meta_scopes | An array of meta scope names. These are the labels of one ore more special properties in the sample _JWT payload_. They can be found in the _JWT_ tab of the I/O Console integration in the _JWT payload_ properties of the form `"https://<ims-host>/s/ent_dataservices_sdk": true,`. There may be one or more of depending on the services to which the integration is subscribed. The values to list in the **meta_scopes** property are the last segment of the URL. In the example case, this would be `ent_dataservices_sdk`.
 | ims_org_id | The _Organization ID_ from the integration overview screen in the I/O Console. |
 | private_key | The private key matching any one of the _Public Keys_ of the integration. This can be the private key all in one line as a string, or an array of strings (each element is a line from the key file) See the [Setting the Private Key](#setting-the-private-key) section. |
 | passphrase | (_Optional_). The passphrase of the private key. |
 
-
 ## Setting the Private Key
 
-For a JWT configuration, your private key is generated in Adobe I/O Console, and is downloaded to your computer when you generate it. 
+For a JWT configuration, your private key is generated in Adobe I/O Console, and is downloaded to your computer when you generate it.
 
 Adobe I/O Console does not keep the private key (only your corresponding public key) so you will have to set the private key that was downloaded manually in your IMS context configuration.
 
 You can set your private key in the config via two ways:
+
 1. Import the private key as a string
 2. Set a file reference to the private key
 
 The instructions below assume a private key file called `private.key` and `CONTEXT_NAME` is the name of your JWT context.
 
 1. To import your private key as a string:
-
 `aio config:set ims.contexts.CONTEXT_NAME.private_key path/to/your/private.key --file`
-
 2. To set a file reference to the private key instead:
-
 `aio config:set ims.contexts.CONTEXT_NAME.private_key path/to/your/private.key`
 
 Note that the path to your private key, if it is a relative path, will be resolved relative to the current working directory.
@@ -198,9 +194,10 @@ OAuth2 configuration requires the following properties:
 
 ## Token Validation
 
-### Caching 
+### Caching
 
-Validations and invalidations can be cached to improve performance. To use caching, configure a new cache and pass it to the library during initialization: 
+Validations and invalidations can be cached to improve performance. To use caching, configure a new cache and pass it to the library during initialization:
+
 ```js
 const { Ims, ValidationCache, getToken} = require('@adobe/aio-lib-ims')
 
@@ -219,7 +216,8 @@ if (!imsValidation.valid) {
 
 ### Allow List
 
-You can validate a token against an allow-list of IMS clients. To use an allow-list, pass your token and an array of IMS clients to `validateTokenAllowList()`: 
+You can validate a token against an allow-list of IMS clients. To use an allow-list, pass your token and an array of IMS clients to `validateTokenAllowList()`:
+
 ```js
 const { Ims } = require('@adobe/aio-lib-ims')
 const ims = new Ims()
@@ -231,10 +229,11 @@ if (!imsValidation.valid) {
   return new Error('Forbidden: This client is not allowed!')
 }
 ```
-# Contributing
+
+## Contributing
+
 Contributions are welcomed! Read the [Contributing Guide](CONTRIBUTING.md) for more information.
 
-
-# Licensing
+## Licensing
 
 This project is licensed under the Apache V2 License. See [LICENSE](LICENSE) for more information.

--- a/api.md
+++ b/api.md
@@ -3,7 +3,7 @@
 ## Modules
 
 <dl>
-<dt><a href="#module_@adobe/aio-lib-ims">@adobe/aio-lib-ims</a></dt>
+<dt><a href="#module_aio-lib-ims">aio-lib-ims</a></dt>
 <dd><p>The <code>@adobe/aio-lib-ims</code> module offers three kinds of elements:</p>
 <ol>
 <li>Managing configuration contexts for token creation and use</li>
@@ -57,6 +57,12 @@ cloud using the Adobe I/O State Library.</p>
 <dt><a href="#CURRENT">CURRENT</a></dt>
 <dd><p>Property holding the current context name</p>
 </dd>
+<dt><a href="#Updater">Updater</a></dt>
+<dd><p>Create an Updater for the Error wrapper</p>
+</dd>
+<dt><a href="#E">E</a></dt>
+<dd><p>Provides a wrapper to easily create classes of a certain name, and values</p>
+</dd>
 <dt><a href="#ACCESS_TOKEN">ACCESS_TOKEN</a></dt>
 <dd><p>The constant string <code>access_token</code>.</p>
 </dd>
@@ -65,6 +71,9 @@ cloud using the Adobe I/O State Library.</p>
 </dd>
 <dt><a href="#AUTHORIZATION_CODE">AUTHORIZATION_CODE</a></dt>
 <dd><p>The constant string <code>authorization_code</code>.</p>
+</dd>
+<dt><a href="#CLIENT_CREDENTIALS">CLIENT_CREDENTIALS</a></dt>
+<dd><p>The constant string <code>client_credentials</code>.</p>
 </dd>
 <dt><a href="#CLIENT_ID">CLIENT_ID</a></dt>
 <dd><p>The constant string <code>client_id</code>.</p>
@@ -88,100 +97,89 @@ cloud using the Adobe I/O State Library.</p>
 </dd>
 </dl>
 
-<a name="module_@adobe/aio-lib-ims"></a>
+<a name="module_aio-lib-ims"></a>
 
-## @adobe/aio-lib-ims
-The `@adobe/aio-lib-ims` module offers three kinds of elements:
-
-1. Managing configuration contexts for token creation and use
-2. Creating and invalidating tokens
-3. Providing low level access to IMS API
+## aio-lib-ims
+The `@adobe/aio-lib-ims` module offers three kinds of elements:1. Managing configuration contexts for token creation and use2. Creating and invalidating tokens3. Providing low level access to IMS API
 
 
-* [@adobe/aio-lib-ims](#module_@adobe/aio-lib-ims)
-    * [.getTokenData](#module_@adobe/aio-lib-ims.getTokenData)
-    * [.Ims](#module_@adobe/aio-lib-ims.Ims)
-    * [.ACCESS_TOKEN](#module_@adobe/aio-lib-ims.ACCESS_TOKEN)
-    * [.REFRESH_TOKEN](#module_@adobe/aio-lib-ims.REFRESH_TOKEN)
-    * [.AUTHORIZATION_CODE](#module_@adobe/aio-lib-ims.AUTHORIZATION_CODE)
-    * [.CLIENT_ID](#module_@adobe/aio-lib-ims.CLIENT_ID)
-    * [.CLIENT_SECRET](#module_@adobe/aio-lib-ims.CLIENT_SECRET)
-    * [.SCOPE](#module_@adobe/aio-lib-ims.SCOPE)
-    * [.context](#module_@adobe/aio-lib-ims.context)
-    * [.getToken(contextName, [force])](#module_@adobe/aio-lib-ims.getToken) ⇒ <code>Promise</code>
-    * [.invalidateToken(contextName, [force])](#module_@adobe/aio-lib-ims.invalidateToken) ⇒ <code>Promise</code>
+* [aio-lib-ims](#module_aio-lib-ims)
+    * [.getTokenData](#module_aio-lib-ims.getTokenData)
+    * [.Ims](#module_aio-lib-ims.Ims)
+    * [.ACCESS_TOKEN](#module_aio-lib-ims.ACCESS_TOKEN)
+    * [.REFRESH_TOKEN](#module_aio-lib-ims.REFRESH_TOKEN)
+    * [.AUTHORIZATION_CODE](#module_aio-lib-ims.AUTHORIZATION_CODE)
+    * [.CLIENT_ID](#module_aio-lib-ims.CLIENT_ID)
+    * [.CLIENT_SECRET](#module_aio-lib-ims.CLIENT_SECRET)
+    * [.SCOPE](#module_aio-lib-ims.SCOPE)
+    * [.context](#module_aio-lib-ims.context)
+    * [.getToken(contextName, options)](#module_aio-lib-ims.getToken) ⇒ <code>Promise</code>
+    * [.invalidateToken(contextName, [force])](#module_aio-lib-ims.invalidateToken) ⇒ <code>Promise</code>
 
-<a name="module_@adobe/aio-lib-ims.getTokenData"></a>
+<a name="module_aio-lib-ims.getTokenData"></a>
 
-### @adobe/aio-lib-ims.getTokenData
-**Kind**: static property of [<code>@adobe/aio-lib-ims</code>](#module_@adobe/aio-lib-ims)  
+### aio-lib-ims.getTokenData
+**Kind**: static property of [<code>aio-lib-ims</code>](#module_aio-lib-ims)  
 **See**: [`getTokenData`](#gettokendata)  
-<a name="module_@adobe/aio-lib-ims.Ims"></a>
+<a name="module_aio-lib-ims.Ims"></a>
 
-### @adobe/aio-lib-ims.Ims
-**Kind**: static property of [<code>@adobe/aio-lib-ims</code>](#module_@adobe/aio-lib-ims)  
+### aio-lib-ims.Ims
+**Kind**: static property of [<code>aio-lib-ims</code>](#module_aio-lib-ims)  
 **See**: [`Ims`](#ims)  
-<a name="module_@adobe/aio-lib-ims.ACCESS_TOKEN"></a>
+<a name="module_aio-lib-ims.ACCESS_TOKEN"></a>
 
-### @adobe/aio-lib-ims.ACCESS\_TOKEN
-**Kind**: static property of [<code>@adobe/aio-lib-ims</code>](#module_@adobe/aio-lib-ims)  
+### aio-lib-ims.ACCESS\_TOKEN
+**Kind**: static property of [<code>aio-lib-ims</code>](#module_aio-lib-ims)  
 **See**: [`ACCESS_TOKEN`](#access_token)  
-<a name="module_@adobe/aio-lib-ims.REFRESH_TOKEN"></a>
+<a name="module_aio-lib-ims.REFRESH_TOKEN"></a>
 
-### @adobe/aio-lib-ims.REFRESH\_TOKEN
-**Kind**: static property of [<code>@adobe/aio-lib-ims</code>](#module_@adobe/aio-lib-ims)  
+### aio-lib-ims.REFRESH\_TOKEN
+**Kind**: static property of [<code>aio-lib-ims</code>](#module_aio-lib-ims)  
 **See**: [`REFRESH_TOKEN`](#refresh_token)  
-<a name="module_@adobe/aio-lib-ims.AUTHORIZATION_CODE"></a>
+<a name="module_aio-lib-ims.AUTHORIZATION_CODE"></a>
 
-### @adobe/aio-lib-ims.AUTHORIZATION\_CODE
-**Kind**: static property of [<code>@adobe/aio-lib-ims</code>](#module_@adobe/aio-lib-ims)  
+### aio-lib-ims.AUTHORIZATION\_CODE
+**Kind**: static property of [<code>aio-lib-ims</code>](#module_aio-lib-ims)  
 **See**: [`AUTHORIZATION_CODE`](#authorization_code)  
-<a name="module_@adobe/aio-lib-ims.CLIENT_ID"></a>
+<a name="module_aio-lib-ims.CLIENT_ID"></a>
 
-### @adobe/aio-lib-ims.CLIENT\_ID
-**Kind**: static property of [<code>@adobe/aio-lib-ims</code>](#module_@adobe/aio-lib-ims)  
+### aio-lib-ims.CLIENT\_ID
+**Kind**: static property of [<code>aio-lib-ims</code>](#module_aio-lib-ims)  
 **See**: [`CLIENT_ID`](#client_id)  
-<a name="module_@adobe/aio-lib-ims.CLIENT_SECRET"></a>
+<a name="module_aio-lib-ims.CLIENT_SECRET"></a>
 
-### @adobe/aio-lib-ims.CLIENT\_SECRET
-**Kind**: static property of [<code>@adobe/aio-lib-ims</code>](#module_@adobe/aio-lib-ims)  
+### aio-lib-ims.CLIENT\_SECRET
+**Kind**: static property of [<code>aio-lib-ims</code>](#module_aio-lib-ims)  
 **See**: [`CLIENT_SECRET`](#client_secret)  
-<a name="module_@adobe/aio-lib-ims.SCOPE"></a>
+<a name="module_aio-lib-ims.SCOPE"></a>
 
-### @adobe/aio-lib-ims.SCOPE
-**Kind**: static property of [<code>@adobe/aio-lib-ims</code>](#module_@adobe/aio-lib-ims)  
+### aio-lib-ims.SCOPE
+**Kind**: static property of [<code>aio-lib-ims</code>](#module_aio-lib-ims)  
 **See**: [`SCOPE`](#scope)  
-<a name="module_@adobe/aio-lib-ims.context"></a>
+<a name="module_aio-lib-ims.context"></a>
 
-### @adobe/aio-lib-ims.context
-**Kind**: static property of [<code>@adobe/aio-lib-ims</code>](#module_@adobe/aio-lib-ims)  
+### aio-lib-ims.context
+**Kind**: static property of [<code>aio-lib-ims</code>](#module_aio-lib-ims)  
 **See**: [`Context`](#context)  
-<a name="module_@adobe/aio-lib-ims.getToken"></a>
+<a name="module_aio-lib-ims.getToken"></a>
 
-### @adobe/aio-lib-ims.getToken(contextName, [force]) ⇒ <code>Promise</code>
-Returns an access token for the given context name. When running in Adobe I/O Runtime
-tokens will be persisted in the [`State SDK`](https://github.com/adobe/aio-lib-state).
+### aio-lib-ims.getToken(contextName, options) ⇒ <code>Promise</code>
+Returns an access token for the given context name. When running in Adobe I/O Runtimetokens will be persisted in the [`State SDK`](https://github.com/adobe/aio-lib-state).
 
-**Kind**: static method of [<code>@adobe/aio-lib-ims</code>](#module_@adobe/aio-lib-ims)  
+**Kind**: static method of [<code>aio-lib-ims</code>](#module_aio-lib-ims)  
 **Returns**: <code>Promise</code> - Resolving to an access token (string)  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | contextName | <code>string</code> | The name of the IMS context for which to return the              access token. If this is empty, the token(s) of the current IMS context              are invalidated. |
-| [force] | <code>boolean</code> | Forces a login in the selected plugin's `imslogin` function.              See [Forced `imsLogin`](README.md#forced-imslogin) for more information              on this flag. The default value is `false`. |
+| options | <code>object</code> | A set of arbitrary options which will be passed to the underlying login plugin. |
 
-<a name="module_@adobe/aio-lib-ims.invalidateToken"></a>
+<a name="module_aio-lib-ims.invalidateToken"></a>
 
-### @adobe/aio-lib-ims.invalidateToken(contextName, [force]) ⇒ <code>Promise</code>
-Invalidates the access and optionally refresh of an IMS context.
-The name of the IMS context is given as its first parameter and defaults
-to the current context if missing or empty. The force parameter indicates
-whether only the access token is invalidated (force=false) or the refresh
-token (if existing) is also invalidated (force=true). If the refresh token
-exists and is validated, all access tokens which have been created with
-this refresh token will automatically become invalid as well.
+### aio-lib-ims.invalidateToken(contextName, [force]) ⇒ <code>Promise</code>
+Invalidates the access and optionally refresh of an IMS context.The name of the IMS context is given as its first parameter and defaultsto the current context if missing or empty. The force parameter indicateswhether only the access token is invalidated (force=false) or the refreshtoken (if existing) is also invalidated (force=true). If the refresh tokenexists and is validated, all access tokens which have been created withthis refresh token will automatically become invalid as well.
 
-**Kind**: static method of [<code>@adobe/aio-lib-ims</code>](#module_@adobe/aio-lib-ims)  
+**Kind**: static method of [<code>aio-lib-ims</code>](#module_aio-lib-ims)  
 **Returns**: <code>Promise</code> - Promise that resolves with the request data  
 
 | Param | Type | Description |
@@ -204,6 +202,7 @@ The `Ims` class wraps the IMS API.
         * [.get(api, token, parameters)](#Ims+get) ⇒ <code>Promise</code>
         * [.post(api, token, parameters)](#Ims+post) ⇒ <code>Promise</code>
         * [.getAccessToken(authCode, clientId, clientSecret, scopes)](#Ims+getAccessToken) ⇒ <code>Promise</code>
+        * [.getAccessTokenByClientCredentials(clientId, clientSecret, orgId, scopes)](#Ims+getAccessTokenByClientCredentials) ⇒ <code>Promise</code>
         * [.exchangeJwtToken(clientId, clientSecret, signedJwtToken)](#Ims+exchangeJwtToken) ⇒ <code>Promise</code>
         * [.invalidateToken(token, clientId, clientSecret)](#Ims+invalidateToken) ⇒ <code>Promise</code>
         * [.validateToken(token, [clientId])](#Ims+validateToken) ⇒ <code>object</code>
@@ -220,16 +219,12 @@ Creates a new IMS connector instance for the stage or prod environment
 
 | Param | Type | Description |
 | --- | --- | --- |
-| env | <code>string</code> | The name of the environment. `prod` and `stage`      are the only values supported. `prod` is default and any value      other than `prod` or `stage` stage is assumed to be the default      value of `prod`. |
+| env | <code>string</code> | The name of the environment. `prod` and `stage`      are the only values supported. `prod` is default and any value      other than `prod` or `stage` it is assumed to be the default      value of `prod`. If not set, it will get the global cli env value. See https://github.com/adobe/aio-lib-env      (which defaults to `prod` as well if not set) |
 
 <a name="Ims+getApiUrl"></a>
 
 ### ims.getApiUrl(api) ⇒ <code>string</code>
-Returns the absolute URL to call the indicated API.
-The API is expected to be the API absolute path, such as `/ims/profile`.
-To form the absolute URL, the scheme (`https`) and fully qualified
-domain of the IMS host for this instance's environment is prepended
-to the path.
+Returns the absolute URL to call the indicated API.The API is expected to be the API absolute path, such as `/ims/profile`.To form the absolute URL, the scheme (`https`) and fully qualifieddomain of the IMS host for this instance's environment is prependedto the path.
 
 **Kind**: instance method of [<code>Ims</code>](#Ims)  
 **Returns**: <code>string</code> - The absolute URI for the IMS API  
@@ -241,9 +236,7 @@ to the path.
 <a name="Ims+getSusiUrl"></a>
 
 ### ims.getSusiUrl(clientId, scopes, callbackUrl, state) ⇒ <code>string</code>
-Returns the URL for the environment of this instance which allows
-for OAuth2 based three-legged authentication with a browser for
-an end user.
+Returns the URL for the environment of this instance which allowsfor OAuth2 based three-legged authentication with a browser foran end user.
 
 **Kind**: instance method of [<code>Ims</code>](#Ims)  
 **Returns**: <code>string</code> - the OAuth2 login URL  
@@ -258,8 +251,7 @@ an end user.
 <a name="Ims+get"></a>
 
 ### ims.get(api, token, parameters) ⇒ <code>Promise</code>
-Send a `GET` request to an IMS API with the access token sending
-the `parameters` as request URL parameters.
+Send a `GET` request to an IMS API with the access token sendingthe `parameters` as request URL parameters.
 
 **Kind**: instance method of [<code>Ims</code>](#Ims)  
 **Returns**: <code>Promise</code> - a promise resolving to the result of the request  
@@ -273,8 +265,7 @@ the `parameters` as request URL parameters.
 <a name="Ims+post"></a>
 
 ### ims.post(api, token, parameters) ⇒ <code>Promise</code>
-Send a `POST` request to an IMS API with the access token sending
-the `parameters` as form data.
+Send a `POST` request to an IMS API with the access token sendingthe `parameters` as form data.
 
 **Kind**: instance method of [<code>Ims</code>](#Ims)  
 **Returns**: <code>Promise</code> - a promise resolving to the result of the request  
@@ -288,29 +279,10 @@ the `parameters` as form data.
 <a name="Ims+getAccessToken"></a>
 
 ### ims.getAccessToken(authCode, clientId, clientSecret, scopes) ⇒ <code>Promise</code>
-Request the access token for the given client providing the access
-grant in the `authCode`.
-The promise resolve to the token result JavaScript object as follows:
-
-```js
-{
-  access_token: {
-    token: "eyJ4NXUiOi...6ZodTesbag",
-    expiry: 1566242851048
-  },
-  refresh_token: {
-    token: "eyJ4NXUiOi...YbT1_szWZA",
-    expiry: 1567366051050
-  },
-  payload: {
-     ...full api response...
-  }
-}
-```
+Request the access token for the given client providing the accessgrant in the `authCode`.The promise resolve to the token result JavaScript object as follows:```js{  access_token: {    token: "eyJ4NXUiOi...6ZodTesbag",    expiry: 1566242851048  },  refresh_token: {    token: "eyJ4NXUiOi...YbT1_szWZA",    expiry: 1567366051050  },  payload: {     ...full api response...  }}```
 
 **Kind**: instance method of [<code>Ims</code>](#Ims)  
-**Returns**: <code>Promise</code> - a promise resolving to a tokens object as described in the
-     [toTokenResult](toTokenResult) or rejects to an error message.  
+**Returns**: <code>Promise</code> - a promise resolving to a tokens object as described in the     [toTokenResult](toTokenResult) or rejects to an error message.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -319,26 +291,25 @@ The promise resolve to the token result JavaScript object as follows:
 | clientSecret | <code>string</code> | The Client Secrete proving client ID ownership |
 | scopes | <code>string</code> | The list of scopes to request as a blank separated list |
 
+<a name="Ims+getAccessTokenByClientCredentials"></a>
+
+### ims.getAccessTokenByClientCredentials(clientId, clientSecret, orgId, scopes) ⇒ <code>Promise</code>
+Request an access token of the Client Credentials Grant Type.
+
+**Kind**: instance method of [<code>Ims</code>](#Ims)  
+**Returns**: <code>Promise</code> - a promise resolving to a tokens object as described in the     [toTokenResult](toTokenResult) or rejects to an error message.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| clientId | <code>string</code> | The Client ID |
+| clientSecret | <code>string</code> | The Client Secret proving client ID ownership |
+| orgId | <code>string</code> | the IMS org Id |
+| scopes | <code>Array.&lt;string&gt;</code> | The list of scopes to request as a blank separated list |
+
 <a name="Ims+exchangeJwtToken"></a>
 
 ### ims.exchangeJwtToken(clientId, clientSecret, signedJwtToken) ⇒ <code>Promise</code>
-Asks for the signed JWT token to be exchanged for a valid access
-token as well as a refresh token.
-The promise resolve to the token result JavaScript object as follows:
-
-```js
-{
-  access_token: {
-    token: "eyJ4NXUiOi...6ZodTesbag",
-    expiry: 1566242851048
-  },
-  payload: {
-     ...full api response...
-  }
-}
-```
-
-Note that there is no `refresh_token` in a JWT tokan exchange.
+Asks for the signed JWT token to be exchanged for a valid accesstoken as well as a refresh token.The promise resolve to the token result JavaScript object as follows:```js{  access_token: {    token: "eyJ4NXUiOi...6ZodTesbag",    expiry: 1566242851048  },  payload: {     ...full api response...  }}```Note that there is no `refresh_token` in a JWT token exchange.
 
 **Kind**: instance method of [<code>Ims</code>](#Ims)  
 **Returns**: <code>Promise</code> - returns a Promise that resolves to the token result object  
@@ -352,9 +323,7 @@ Note that there is no `refresh_token` in a JWT tokan exchange.
 <a name="Ims+invalidateToken"></a>
 
 ### ims.invalidateToken(token, clientId, clientSecret) ⇒ <code>Promise</code>
-Invalidates the given token. If the token is a refresh token, all the
-access tokens created with that refresh token will also be invalidated
-at the same time.
+Invalidates the given token. If the token is a refresh token, all theaccess tokens created with that refresh token will also be invalidatedat the same time.
 
 **Kind**: instance method of [<code>Ims</code>](#Ims)  
 **Returns**: <code>Promise</code> - Promise that resolves with the request data  
@@ -393,19 +362,7 @@ Gets the IMS organizations attached to the given token.
 <a name="Ims+toTokenResult"></a>
 
 ### ims.toTokenResult(token) ⇒ <code>Promise</code>
-Converts the access token to a token result object as follows:
-
-```js
-{
-  access_token: {
-    token: "eyJ4NXUiOi...6ZodTesbag",
-    expiry: 1566242851048
-  }
-}
-```
-
-The `expiry` property is the expiry time of the token in milliseconds
-since the epoch.
+Converts the access token to a token result object as follows:```js{  access_token: {    token: "eyJ4NXUiOi...6ZodTesbag",    expiry: 1566242851048  }}```The `expiry` property is the expiry time of the token in millisecondssince the epoch.
 
 **Kind**: instance method of [<code>Ims</code>](#Ims)  
 **Returns**: <code>Promise</code> - a `Promise` resolving to an object as described.  
@@ -417,8 +374,7 @@ since the epoch.
 <a name="Ims.fromToken"></a>
 
 ### Ims.fromToken(token) ⇒ <code>Promise</code>
-Creates an instance of the `Ims` class deriving the instance's
-environment from the `as` claim in the provided access token.
+Creates an instance of the `Ims` class deriving the instance'senvironment from the `as` claim in the provided access token.
 
 **Kind**: static method of [<code>Ims</code>](#Ims)  
 **Returns**: <code>Promise</code> - A `Promise` resolving to the `Ims` instance.  
@@ -430,8 +386,7 @@ environment from the `as` claim in the provided access token.
 <a name="ConfigCliContext"></a>
 
 ## ConfigCliContext
-The `ConfigCliContext` class stores IMS `contexts` for the Adobe I/O CLI in the local file
-system using the Adobe I/O Core Configuration Library.
+The `ConfigCliContext` class stores IMS `contexts` for the Adobe I/O CLI in the local filesystem using the Adobe I/O Core Configuration Library.
 
 **Kind**: global class  
 
@@ -462,8 +417,7 @@ Sets the cli context data
 <a name="Context"></a>
 
 ## Context
-The `Context` abstract class provides an interface to manage the IMS configuration contexts on behalf of
-the Adobe I/O Lib IMS Library.
+The `Context` abstract class provides an interface to manage the IMS configuration contexts on behalf ofthe Adobe I/O Lib IMS Library.
 
 **Kind**: global class  
 
@@ -496,12 +450,7 @@ Sets the current context name in the local configuration
 <a name="Context+get"></a>
 
 ### context.get(contextName) ⇒ <code>Promise.&lt;object&gt;</code>
-Returns an object representing the named context.
-If the contextName parameter is empty or missing, it defaults to the
-current context name. The result is an object with two properties:
-
-  - `name`: The actual context name used
-  - `data`: The IMS context data
+Returns an object representing the named context.If the contextName parameter is empty or missing, it defaults to thecurrent context name. The result is an object with two properties:  - `name`: The actual context name used  - `data`: The IMS context data
 
 **Kind**: instance method of [<code>Context</code>](#Context)  
 **Returns**: <code>Promise.&lt;object&gt;</code> - The configuration object  
@@ -513,9 +462,7 @@ current context name. The result is an object with two properties:
 <a name="Context+set"></a>
 
 ### context.set(contextName, contextData, local)
-Updates the named configuration with new configuration data. If a configuration
-object for the named context already exists it is completely replaced with this new
-configuration.
+Updates the named configuration with new configuration data. If a configurationobject for the named context already exists it is completely replaced with this newconfiguration.
 
 **Kind**: instance method of [<code>Context</code>](#Context)  
 
@@ -535,8 +482,7 @@ Returns the names of the configured contexts as an array of strings.
 <a name="StateActionContext"></a>
 
 ## StateActionContext
-The `StateActionContext` class stores IMS `contexts` for Adobe I/O Runtime Actions in the
-cloud using the Adobe I/O State Library.
+The `StateActionContext` class stores IMS `contexts` for Adobe I/O Runtime Actions in thecloud using the Adobe I/O State Library.
 
 **Kind**: global class  
 <a name="TYPE_ACTION"></a>
@@ -581,6 +527,18 @@ Property holding the cli context name
 Property holding the current context name
 
 **Kind**: global constant  
+<a name="Updater"></a>
+
+## Updater
+Create an Updater for the Error wrapper
+
+**Kind**: global constant  
+<a name="E"></a>
+
+## E
+Provides a wrapper to easily create classes of a certain name, and values
+
+**Kind**: global constant  
 <a name="ACCESS_TOKEN"></a>
 
 ## ACCESS\_TOKEN
@@ -597,6 +555,12 @@ The constant string `refresh_token`.
 
 ## AUTHORIZATION\_CODE
 The constant string `authorization_code`.
+
+**Kind**: global constant  
+<a name="CLIENT_CREDENTIALS"></a>
+
+## CLIENT\_CREDENTIALS
+The constant string `client_credentials`.
 
 **Kind**: global constant  
 <a name="CLIENT_ID"></a>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@adobe/aio-lib-core-networking": "^3.0.0",
     "@adobe/aio-lib-env": "^2.0.0",
     "@adobe/aio-lib-ims-jwt": "^4.0.0",
-    "@adobe/aio-lib-ims-oauth": "^5.0.0",
+    "@adobe/aio-lib-ims-oauth": "github:adobe/aio-lib-ims-oauth#story/ACNA-1854",
     "@adobe/aio-lib-state": "^2.0.1",
     "form-data": "^4.0.0",
     "lodash.clonedeep": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "scripts": {
     "posttest": "eslint src test",
     "test": "npm run unit-tests",
-    "unit-tests": "jest --config test/jest.config.js ---ci -w=2",
+    "unit-tests": "jest --config test/jest.config.js --ci -w=2",
     "e2e": "jest --config e2e/jest.config.js",
     "docs": "jsdoc2md --template jsdoc2md/api.hbs src/*.js src/**/*.js > api.md",
     "version": "git add README.md"

--- a/src/ims.js
+++ b/src/ims.js
@@ -356,12 +356,12 @@ class Ims {
   }
 
   /**
-   * Request an access token of the Client Credentials Grant Type. 
+   * Request an access token of the Client Credentials Grant Type.
    *
    * @param {string} clientId The Client ID
    * @param {string} clientSecret The Client Secret proving client ID ownership
    * @param {string} orgId the IMS org Id
-   * @param {array<string>} scopes The list of scopes to request as a blank separated list
+   * @param {Array<string>} scopes The list of scopes to request as a blank separated list
    * @returns {Promise} a promise resolving to a tokens object as described in the
    *      {@link toTokenResult} or rejects to an error message.
    */

--- a/src/ims.js
+++ b/src/ims.js
@@ -372,7 +372,7 @@ class Ims {
    *      {@link toTokenResult} or rejects to an error message.
    */
   async getAccessTokenByClientCredentials (clientId, clientSecret, orgId, scopes) {
-    aioLogger.debug('getAccessTokenServerToServer(%s, %s, %s, %o)', clientId, clientSecret, orgId, scopes = [])
+    aioLogger.debug('getAccessTokenByClientCredentials(%s, %s, %s, %o)', clientId, clientSecret, orgId, scopes = [])
 
     // prepare the data with common data
     const postData = {

--- a/src/ims.js
+++ b/src/ims.js
@@ -31,6 +31,9 @@ const REFRESH_TOKEN = 'refresh_token'
 /** The constant string `authorization_code`.  */
 const AUTHORIZATION_CODE = 'authorization_code'
 
+/** The constant string `client_credentials`.  */
+const CLIENT_CREDENTIALS = 'client_credentials'
+
 /** The constant string `client_id`.  */
 const CLIENT_ID = 'client_id'
 
@@ -349,6 +352,32 @@ class Ims {
     }
 
     return _sendPost(this.getApiUrl('/ims/token/v1'), undefined, postData)
+      .then(_toTokenResult)
+  }
+
+  /**
+   * Request an access token of the Client Credentials Grant Type. 
+   *
+   * @param {string} clientId The Client ID
+   * @param {string} clientSecret The Client Secret proving client ID ownership
+   * @param {string} orgId the IMS org Id
+   * @param {array<string>} scopes The list of scopes to request as a blank separated list
+   * @returns {Promise} a promise resolving to a tokens object as described in the
+   *      {@link toTokenResult} or rejects to an error message.
+   */
+  async getAccessTokenServerToServer (clientId, clientSecret, orgId, scopes) {
+    aioLogger.debug('getAccessTokenServerToServer(%s, %s, %s, %o)', clientId, clientSecret, orgId, scopes = [])
+
+    // prepare the data with common data
+    const postData = {
+      grant_type: CLIENT_CREDENTIALS,
+      client_id: clientId,
+      client_secret: clientSecret,
+      org_id: orgId,
+      scope: scopes.join(',')
+    }
+
+    return _sendPost(this.getApiUrl('/ims/token/v2'), undefined, postData)
       .then(_toTokenResult)
   }
 

--- a/src/ims.js
+++ b/src/ims.js
@@ -365,7 +365,7 @@ class Ims {
    * @returns {Promise} a promise resolving to a tokens object as described in the
    *      {@link toTokenResult} or rejects to an error message.
    */
-  async getAccessTokenServerToServer (clientId, clientSecret, orgId, scopes) {
+  async getAccessTokenByClientCredentials (clientId, clientSecret, orgId, scopes) {
     aioLogger.debug('getAccessTokenServerToServer(%s, %s, %s, %o)', clientId, clientSecret, orgId, scopes = [])
 
     // prepare the data with common data

--- a/src/token-helper.js
+++ b/src/token-helper.js
@@ -33,12 +33,14 @@ const ACTION_BUILD = (typeof WEBPACK_ACTION_BUILD === 'undefined') ? false : WEB
 if (!ACTION_BUILD) {
   // use OAuth and CLI imports only when WEBPACK_ACTION_BUILD global is not set
   const imsCliPlugin = require('@adobe/aio-lib-ims-oauth/src/ims-cli')
+  const imsOAuthSTSPlugin = require('@adobe/aio-lib-ims-oauth/src/ims-oauth_server_to_server')
   const imsOAuthPlugin = require('@adobe/aio-lib-ims-oauth')
 
   DEFAULT_CREATE_TOKEN_PLUGINS = {
     cli: imsCliPlugin,
     jwt: imsJwtPlugin,
-    oauth: imsOAuthPlugin
+    oauth: imsOAuthPlugin,
+    oauthSTS: imsOAuthSTSPlugin
   }
 }
 

--- a/test/ims.test.js
+++ b/test/ims.test.js
@@ -740,8 +740,7 @@ test('Ims.getAccessTokenByClientCredentials', async () => {
   const scopes = ['some', 'things']
 
   const serverResponsePayload = {
-    access_token: '',
-    refresh_token: ''
+    access_token: ''
   }
 
   const res = {

--- a/test/ims.test.js
+++ b/test/ims.test.js
@@ -519,3 +519,28 @@ test('Ims.getSusiUrl - callbackUrl null', () => {
       'https://ims-na1.adobelogin.com/ims/authorize/v1?response_type=code&client_id=some-client-id&scope=some%2C+scopes&state=some-state'
     )
 })
+
+test('Ims.getAccessTokenByClientCredentials', async () => {
+  const ims = new Ims()
+
+  const clientId = 'some-client-id'
+  const clientSecret = 'some-client-secret'
+  const orgId = 'some-org-id'
+  const scopes = ['some', 'things']
+
+  const serverResponsePayload = {
+    access_token: '',
+    refresh_token: ''
+  }
+
+  const res = {
+    status: 200,
+    text: () => Promise.resolve(serverResponsePayload)
+  }
+
+  // have some return value from request module
+  mockExponentialBackoff.mockImplementation(() => Promise.resolve(res))
+
+  await expect(ims.getAccessTokenByClientCredentials(clientId, clientSecret, orgId, scopes))
+    .resolves.toEqual({ payload: serverResponsePayload })
+})

--- a/test/token-helper.test.js
+++ b/test/token-helper.test.js
@@ -31,6 +31,10 @@ const IMS_PLUGINS = {
   oauth: {
     module: '@adobe/aio-lib-ims-oauth',
     imsLogin: jest.fn()
+  },
+  oauthSTS: {
+    module: '@adobe/aio-lib-ims-oauth/src/ims-oauth_server_to_server',
+    imsLogin: jest.fn()
   }
 }
 


### PR DESCRIPTION
## Changes 📦 

- add `Ims.getAccessTokenByClientCredentials` function -- this is an OAuth call with client credentials grant type, to get an access token.

## Pre-requisites 🔖 

- prod dep: https://github.com/adobe/aio-lib-ims-oauth/pull/69

## Pending 🚧 

- Need to update README in this repo
- revert 49cf3107a71037e419f6e6061247805441718598 before merging
- manual tests pending

## How Has This Been Tested? 🔧 

- npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
