### PR TITLE
feat: validation caching and allow list

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,13 +213,13 @@ const ims = new Ims('prod', cache)
 const token = params.theToken // May be passed via header, parameter, or other input
 const imsValidation = await ims.validateToken(token)
 if (!imsValidation.valid) {
-  return new Error('Forbidden: This is not a valid IMS token!') // Next time validateToken() is called with this token, a call to IMS will not be made while the cache has not expired
+  return new Error('Forbidden: This is not a valid IMS token!') // Next time validateToken() is called with this token, a call to IMS will not be made while the cache is still fresh
 }
 ```
 
 ### Allow List
 
-You can validate a token against an allow-list of IMS clients. To use an allow-list, your token and an array of IMS clients to `validateTokenAllowList()`: 
+You can validate a token against an allow-list of IMS clients. To use an allow-list, pass your token and an array of IMS clients to `validateTokenAllowList()`: 
 ```js
 const { Ims } = require('@adobe/aio-lib-ims')
 const ims = new Ims()

--- a/README.md
+++ b/README.md
@@ -196,6 +196,41 @@ OAuth2 configuration requires the following properties:
 | redirect_uri | The _Default redirect URI_ from the integration overview screen in the I/O Console. Alternatively, any URI matching one of the _Redirect URI patterns_ may be used. |
 | scope | Scopes to assign to the tokens. This is a string of space separated scope names which depends on the services this integration is subscribed to. Adobe I/O Console does not currently expose the list of scopes defined for OAuth2 integrations, a good list of scopes by service can be found in [OAuth 2.0 Scopes](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/OAuth/Scopes.md). At the very least you may want to enter `openid`. |
 
+## Token Validation
+
+### Caching 
+
+Validations and invalidations can be cached to improve performance. To use caching, configure a new cache and pass it to the library during initialization: 
+```js
+const { Ims, ValidationCache, getToken} = require('@adobe/aio-lib-ims')
+
+const CACHE_MAX_AGE_MS = 5 * 60 * 1000 // 5 minutes
+const VALID_CACHE_ENTRIES = 10000
+const INVALID_CACHE_ENTRIES = 20000
+const cache = new ValidationCache(CACHE_MAX_AGE_MS, VALID_CACHE_ENTRIES, INVALID_CACHE_ENTRIES)
+const ims = new Ims('prod', cache)
+
+const token = params.theToken // May be passed via header, parameter, or other input
+const imsValidation = await ims.validateToken(token)
+if (!imsValidation.valid) {
+  return new Error('Forbidden: This is not a valid IMS token!') // Next time validateToken() is called with this token, a call to IMS will not be made while the cache has not expired
+}
+```
+
+### Allow List
+
+You can validate a token against an allow-list of IMS clients. To use an allow-list, your token and an array of IMS clients to `validateTokenAllowList()`: 
+```js
+const { Ims } = require('@adobe/aio-lib-ims')
+const ims = new Ims()
+
+const token = params.theToken // May be passed via header, parameter, or other input
+const allowList = ['ironmaiden', 'metallica', 'gunsandroses']
+const imsValidation = await ims.validateTokenAllowList(token, allowList)
+if (!imsValidation.valid) {
+  return new Error('Forbidden: This client is not allowed!')
+}
+```
 # Contributing
 Contributions are welcomed! Read the [Contributing Guide](CONTRIBUTING.md) for more information.
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@adobe/aio-lib-ims-oauth": "^5.0.0",
     "@adobe/aio-lib-state": "^2.0.1",
     "form-data": "^4.0.0",
-    "lodash.clonedeep": "^4.5.0"
+    "lodash.clonedeep": "^4.5.0",
+    "lru-cache": "^9.0.1"
   },
   "devDependencies": {
     "@adobe/aio-lib-test-proxy": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@adobe/aio-lib-state": "^2.0.1",
     "form-data": "^4.0.0",
     "lodash.clonedeep": "^4.5.0",
-    "lru-cache": "^9.0.1"
+    "lru-cache": "^5.1.1"
   },
   "devDependencies": {
     "@adobe/aio-lib-test-proxy": "^1.0.0",

--- a/src/ValidationCache.js
+++ b/src/ValidationCache.js
@@ -1,0 +1,132 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const LRU = require('lru-cache')
+
+/**
+ * @typedef {object} ValidationResult
+ * @property {number} status validation response status code, e.g 200, 401, 403, ...
+ * @property {string} message validation message, e.g. reason of failed validation
+ */
+
+/**
+ * @typedef {Function} ValidationFunction
+ * @param {...string} params validation params used for building the cache key (at least one)
+ * @returns {Promise<ValidationResult>} validation result
+ */
+
+// food for thought:
+// - could we find a better data structure than 2 LRU caches (Maps) memory-wise (e.g. ageing bloom-filters - but problem is false positives)
+
+/**
+ * A class to cache valid or invalid results. Internally two separate cache entries are
+ * maintained. Each cache entry is about 66Bytes big.
+ *
+ * @class ValidationCache
+ */
+class ValidationCache {
+  /**
+   * Creates a new LRU cache instance.
+   *
+   * @param {number} maxAge - The maximum age in milliseconds of cache validity.
+   * @param {number} maxValidEntries - The maximum number of valid entries that can be contained in the cache.
+   * @param {number} maxInvalidEntries - The maximum number of invalid entries that can be contained in the cache.
+   */
+  constructor (maxAge, maxValidEntries, maxInvalidEntries) {
+    // we keep two separate caches, so that invalid entries can't evict valid ones
+    /** @private */
+    this.validCache = new LRU({ max: maxValidEntries, maxAge })
+    /** @private */
+    this.invalidCache = new LRU({ max: maxInvalidEntries, maxAge })
+    // encode each possible response as a 2 byte char
+    /** @private */
+    this.encodingState = {
+      charToResult: {},
+      resultToChar: {},
+      currentCharCode: 1 // start with 1
+    }
+  }
+
+  /**
+   * @param {ValidationResult} res
+   * @returns {string} a single char
+   * @memberof ValidationCache
+   * @private
+   */
+  resultStr (res) {
+    return `${res.status}${res.message}`
+  }
+
+  /**
+   * @param {ValidationResult} res
+   * @returns {string} a single char
+   * @memberof ValidationCache
+   * @private
+   */
+  encodeValidationResult (res) {
+    const resultString = this.resultStr(res)
+    let char = this.encodingState.resultToChar[resultString]
+    if (!char) {
+      // new result type
+      char = String.fromCharCode(this.encodingState.currentCharCode++)
+      this.encodingState.resultToChar[resultString] = char
+      this.encodingState.charToResult[char] = res
+    }
+    return char
+  }
+
+  /**
+   * @param {string} char
+   * @returns {ValidationResult} a validation result entry
+   * @memberof ValidationCache
+   * @private
+   */
+  decodeValidationResult (char) {
+    // should never be null as long as we always encode before decoding
+    return this.encodingState.charToResult[char]
+  }
+
+  /**
+   * @param {Array} params
+   * @returns
+   * @memberof ValidationCache
+   * @private
+   */
+  computeCacheKey (params) {
+    // requires 32 * 2 bytes (2 for each char) in javascript
+    return require('crypto').createHash('sha256').update(params.join('-')).digest().toString()
+  }
+
+  /**
+   *
+   * Applies a validation function and caches the result. If there is a cache entry
+   * available returns the cached result without calling the validation function.
+   * The cache key is computed from the validation params
+   *
+   * @param {ValidationFunction} validationFunction a function that returns an object of the form `{ status, message }`
+   * @param {...string} validationParams  parameters for the validationFunction, must be at least one
+   * @returns {Promise<object>} validation result
+   * @memberof ValidationCache
+   */
+  async validateWithCache (validationFunction, ...validationParams) {
+    const cacheKey = this.computeCacheKey(validationParams)
+    const cachedCode = this.invalidCache.get(cacheKey) || this.validCache.get(cacheKey)
+    if (cachedCode) {
+      return this.decodeValidationResult(cachedCode)
+    }
+    const res = await validationFunction(...validationParams)
+    const cache = res.status < 400 ? this.validCache : this.invalidCache
+    cache.set(cacheKey, this.encodeValidationResult(res))
+    return res
+  }
+}
+
+module.exports = ValidationCache

--- a/src/ims.js
+++ b/src/ims.js
@@ -432,8 +432,8 @@ class Ims {
    * Note: The cache uses the returned status key to determine if the result should be cached. This is not returned
    *       to the user.
    *
-   * @param {*} token the token to validate
-   * @param {*} allowList the allow list to validate against
+   * @param {string} token the token to validate
+   * @param {Array<string>} allowList the allow list to validate against
    * @returns {Promise} Promise that resolves with the ims validation result
    */
   async validateTokenAllowList (token, allowList) {

--- a/src/ims.js
+++ b/src/ims.js
@@ -18,9 +18,6 @@ const { getCliEnv, DEFAULT_ENV } = require('@adobe/aio-lib-env')
 const { codes: errors } = require('./errors')
 
 const ValidationCache = require('./ValidationCache')
-const CACHE_MAX_AGE = 5 * 60 * 1000 // 5 minutes
-const VALID_CACHE_ENTRIES = 100000 // 100K * 66B = ~6.3MB
-const INVALID_CACHE_ENTRIES = 20000000 // 20M * 66B = ~126MB
 
 const IMS_ENDPOINTS = {
   stage: 'https://ims-na1-stg1.adobelogin.com',
@@ -222,13 +219,13 @@ class Ims {
    *      other than `prod` or `stage` it is assumed to be the default
    *      value of `prod`. If not set, it will get the global cli env value. See https://github.com/adobe/aio-lib-env
    *      (which defaults to `prod` as well if not set)
-   *
-   * @param {ValidationCache || boolean} cache The cache instance to use. If 'true' is passed, default cache settings are used.
+   * @param {ValidationCache} cache The cache instance to use.
    */
   constructor (env = getCliEnv(), cache) {
     this.endpoint = IMS_ENDPOINTS[env] || IMS_ENDPOINTS[DEFAULT_ENV]
-    this.cache = cache instanceof ValidationCache ? cache :
-      typeof cache === 'boolean' && cache ? new ValidationCache(CACHE_MAX_AGE, VALID_CACHE_ENTRIES, INVALID_CACHE_ENTRIES) : undefined
+    if (cache) {
+      this.cache = cache
+    }
   }
 
   /**
@@ -435,12 +432,12 @@ class Ims {
    * Note: The cache uses the returned status key to determine if the result should be cached. This is not returned
    *       to the user.
    *
-   * @param {*} token
-   * @param {*} allowList
-   * @returns
+   * @param {*} token the token to validate
+   * @param {*} allowList the allow list to validate against
+   * @returns {Promise} Promise that resolves with the ims validation result
    */
-  async validateTokenAllowList(token, allowList) {
-    aioLogger.debug('validateTokenAllowList(%s, %s)', token, allowList.join(', '))
+  async validateTokenAllowList (token, allowList) {
+    aioLogger.debug('validateTokenAllowList (token): (%s)', token)
 
     const validateAllowList = async (token, allowList) => {
       // Validate the token
@@ -449,7 +446,8 @@ class Ims {
       // Validate token against the allow list
       const tokenData = getTokenData(token)
       const clientId = tokenData.client_id
-      if (allowList && allowList.length > 0) {
+      if (allowList) {
+        aioLogger.debug('validateTokenAllowList (allowList): (%s)', allowList.join(', '))
         if (allowList.indexOf(clientId) === -1) {
           validationResponse = {
             status: 403,

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,8 @@ const {
   SCOPE
 } = require('./ims')
 
+const ValidationCache = require('./ValidationCache')
+
 /**
  * The `@adobe/aio-lib-ims` module offers three kinds of elements:
  *
@@ -40,6 +42,9 @@ module.exports = {
 
   /** @see [`Ims`](#ims) */
   Ims,
+
+  /** @see [`ValidationCache`](#ValidationCache) */
+  ValidationCache,
 
   /** @see [`ACCESS_TOKEN`](#access_token) */
   ACCESS_TOKEN,

--- a/test/ValidationCache.test.js
+++ b/test/ValidationCache.test.js
@@ -1,0 +1,164 @@
+
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+const LRU = require('lru-cache')
+jest.mock('lru-cache')
+
+const ValidationCache = require('../src/ValidationCache')
+
+beforeEach(() => {
+  LRU.mockClear()
+})
+
+const FAKEPARAMSHASH = '���QL�p�/uh}�� DBR�w��`WD2�jP' // sha256 hash of 'afds-b-cf' in binary format
+
+test('constructor (1, 2, 3)', () => {
+  const validationCache = new ValidationCache(1, 2, 3)
+  expect(LRU).toHaveBeenCalledTimes(2)
+  expect(LRU.mock.calls[0][0]).toEqual({ max: 2, maxAge: 1 })
+  expect(LRU.mock.calls[1][0]).toEqual({ max: 3, maxAge: 1 })
+  expect(validationCache.validCache).toBe(LRU.mock.instances[0])
+  expect(validationCache.invalidCache).toBe(LRU.mock.instances[1])
+})
+
+test('validateWithCache(() => { status: 200, message: fake }, a, b, c) no cache', async () => {
+  const validationCache = new ValidationCache(0, 2, 3)
+  const validationFunction = jest.fn().mockResolvedValue({ status: 200, message: 'fake' })
+  const res = await validationCache.validateWithCache(validationFunction, 'afds', 'b', 'cf')
+  expect(res).toEqual({ status: 200, message: 'fake' })
+  expect(validationFunction).toHaveBeenCalledWith('afds', 'b', 'cf')
+  expect(validationCache.validCache.get).toHaveBeenCalledWith(FAKEPARAMSHASH)
+  expect(validationCache.invalidCache.get).toHaveBeenCalledWith(FAKEPARAMSHASH)
+  expect(validationCache.validCache.set).toHaveBeenCalledWith(FAKEPARAMSHASH, '\u0001')
+  expect(validationCache.invalidCache.set).not.toHaveBeenCalled()
+})
+
+test('validateWithCache(() => { status: 200, message: fake }, a, b, c) with cache', async () => {
+  const validationCache = new ValidationCache(0, 2, 3)
+  const validationFunction = jest.fn().mockResolvedValue({ status: 200, message: 'fake' })
+
+  // first call to warmup encoding tables
+  await validationCache.validateWithCache(validationFunction, 'afds', 'b', 'cf')
+  validationFunction.mockClear()
+  // mock cache
+  validationCache.validCache.get.mockReturnValue(validationCache.validCache.set.mock.calls[0][1])
+  // clear calls
+  validationCache.validCache.get.mockClear()
+  validationCache.validCache.set.mockClear()
+  validationCache.invalidCache.get.mockClear()
+  validationCache.invalidCache.set.mockClear()
+
+  const res = await validationCache.validateWithCache(validationFunction, 'afds', 'b', 'cf')
+  expect(res).toEqual({ status: 200, message: 'fake' })
+  expect(validationFunction).not.toHaveBeenCalled()
+  expect(validationCache.validCache.get).toHaveBeenCalledWith(FAKEPARAMSHASH)
+  expect(validationCache.invalidCache.get).toHaveBeenCalledWith(FAKEPARAMSHASH) // checks invalid cache first that's why it's called
+  expect(validationCache.validCache.set).not.toHaveBeenCalled()
+  expect(validationCache.invalidCache.set).not.toHaveBeenCalled()
+})
+
+test('validateWithCache(() => { status: 400, message: fake }, a, b, c) no cache', async () => {
+  const validationCache = new ValidationCache(0, 2, 3)
+  const validationFunction = jest.fn().mockResolvedValue({ status: 400, message: 'fake' })
+  const res = await validationCache.validateWithCache(validationFunction, 'afds', 'b', 'cf')
+  expect(res).toEqual({ status: 400, message: 'fake' })
+  expect(validationFunction).toHaveBeenCalledWith('afds', 'b', 'cf')
+  expect(validationCache.invalidCache.get).toHaveBeenCalledWith(FAKEPARAMSHASH)
+  expect(validationCache.validCache.get).toHaveBeenCalledWith(FAKEPARAMSHASH)
+  expect(validationCache.invalidCache.set).toHaveBeenCalledWith(FAKEPARAMSHASH, '\u0001')
+  expect(validationCache.validCache.set).not.toHaveBeenCalled()
+})
+
+test('validateWithCache(() => { status: 400, message: fake }, a, b, c) with cache', async () => {
+  const validationCache = new ValidationCache(0, 2, 3)
+  const validationFunction = jest.fn().mockResolvedValue({ status: 400, message: 'fake' })
+
+  // first call to warmup encoding tables
+  await validationCache.validateWithCache(validationFunction, 'afds', 'b', 'cf')
+  validationFunction.mockClear()
+  // mock cache
+  validationCache.invalidCache.get.mockReturnValue(validationCache.invalidCache.set.mock.calls[0][1])
+  // clear calls
+  validationCache.validCache.get.mockClear()
+  validationCache.validCache.set.mockClear()
+  validationCache.invalidCache.get.mockClear()
+  validationCache.invalidCache.set.mockClear()
+
+  const res = await validationCache.validateWithCache(validationFunction, 'afds', 'b', 'cf')
+  expect(res).toEqual({ status: 400, message: 'fake' })
+  expect(validationFunction).not.toHaveBeenCalled()
+  expect(validationCache.invalidCache.get).toHaveBeenCalledWith(FAKEPARAMSHASH)
+  expect(validationCache.validCache.get).not.toHaveBeenCalled() // checks invalid cache first
+  expect(validationCache.invalidCache.set).not.toHaveBeenCalled()
+  expect(validationCache.validCache.set).not.toHaveBeenCalled()
+})
+
+test('validateWithCache encoding of response is stored but cache has been evicted', async () => {
+  const validationCache = new ValidationCache(0, 2, 3)
+  const validationFunction = jest.fn()
+
+  // first calls to warmup encoding tables
+  validationFunction.mockResolvedValue({ status: 400, message: 'fake' })
+  await validationCache.validateWithCache(validationFunction, 'afds', 'b', 'cf')
+  validationFunction.mockResolvedValue({ status: 200, message: 'fake1' })
+  await validationCache.validateWithCache(validationFunction, 'afds', 'b', 'cfde')
+  validationFunction.mockResolvedValue({ status: 399, message: 'fake2' })
+  await validationCache.validateWithCache(validationFunction, 'afds', 'b', 'cfd')
+  validationFunction.mockClear()
+
+  // mock no cache
+  validationCache.invalidCache.get.mockReturnValue(undefined)
+  validationCache.validCache.get.mockReturnValue(undefined)
+  // clear calls
+  validationCache.validCache.get.mockClear()
+  validationCache.validCache.set.mockClear()
+  validationCache.invalidCache.get.mockClear()
+  validationCache.invalidCache.set.mockClear()
+
+  validationFunction.mockResolvedValue({ status: 400, message: 'fake' })
+  const res = await validationCache.validateWithCache(validationFunction, 'afdfdasfdsas', 'fdsavvb', 'cfgfdsagdsa')
+  expect(res).toEqual({ status: 400, message: 'fake' })
+  expect(validationFunction).toHaveBeenCalled()
+  expect(validationCache.invalidCache.get).toHaveBeenCalled()
+  expect(validationCache.validCache.get).toHaveBeenCalled()
+  expect(validationCache.invalidCache.set).toHaveBeenCalledWith(expect.any(String), '\u0001') // encoding table stored the response
+  expect(validationCache.validCache.set).not.toHaveBeenCalled()
+
+  // clear calls
+  validationCache.validCache.get.mockClear()
+  validationCache.validCache.set.mockClear()
+  validationCache.invalidCache.get.mockClear()
+  validationCache.invalidCache.set.mockClear()
+
+  validationFunction.mockResolvedValue({ status: 200, message: 'fake1' })
+  const res2 = await validationCache.validateWithCache(validationFunction, 'afdfdasfdsas', 'fdsavvb', 'cfgfdsagdsa')
+  expect(res2).toEqual({ status: 200, message: 'fake1' })
+  expect(validationFunction).toHaveBeenCalled()
+  expect(validationCache.invalidCache.get).toHaveBeenCalled()
+  expect(validationCache.validCache.get).toHaveBeenCalled()
+  expect(validationCache.validCache.set).toHaveBeenCalledWith(expect.any(String), '\u0002') // encoding table stored the response
+  expect(validationCache.invalidCache.set).not.toHaveBeenCalled()
+
+  // clear calls
+  validationCache.validCache.get.mockClear()
+  validationCache.validCache.set.mockClear()
+  validationCache.invalidCache.get.mockClear()
+  validationCache.invalidCache.set.mockClear()
+
+  validationFunction.mockResolvedValue({ status: 206, message: 'new' })
+  const res3 = await validationCache.validateWithCache(validationFunction, 'afdfdasfdsas', 'fdsavvb', 'cfgfdsagdsa')
+  expect(res3).toEqual({ status: 206, message: 'new' })
+  expect(validationFunction).toHaveBeenCalled()
+  expect(validationCache.invalidCache.get).toHaveBeenCalled()
+  expect(validationCache.validCache.get).toHaveBeenCalled()
+  expect(validationCache.validCache.set).toHaveBeenCalledWith(expect.any(String), '\u0004') // new entry in encoding table
+  expect(validationCache.invalidCache.set).not.toHaveBeenCalled()
+})

--- a/test/ims.test.js
+++ b/test/ims.test.js
@@ -21,6 +21,21 @@ jest.mock('@adobe/aio-lib-core-networking', () => ({
   HttpExponentialBackoff: mockHttpExponentialBackoff
 }))
 
+const mockValidationCacheInstance = {
+  validateWithCache: jest.fn().mockImplementation(async (func, ...params) => { return func(...params) })
+}
+
+jest.mock('../src/ValidationCache', () => {
+  const ActualValidationCache = jest.requireActual('../src/ValidationCache')
+
+  return jest.fn().mockImplementation(() => {
+    const validationCache = Object.create(ActualValidationCache.prototype)
+    return Object.assign(validationCache, mockValidationCacheInstance)
+  })
+})
+
+const ValidationCache = require('../src/ValidationCache')
+
 const {
   getTokenData,
   Ims,
@@ -36,6 +51,8 @@ beforeEach(() => {
   mockHttpExponentialBackoff.mockReturnValue({
     exponentialBackoff: mockExponentialBackoff
   })
+  ValidationCache.mockClear()
+  mockValidationCacheInstance.validateWithCache.mockClear()
 })
 
 afterEach(() => {
@@ -98,6 +115,11 @@ test('constructor', () => {
   libEnv.getCliEnv.mockReturnValue(null)
   ims = new Ims()
   expect(ims.endpoint).toEqual(endpoints.PROD_ENV)
+
+  // custom cache
+  const cache = new ValidationCache(1, 2, 3)
+  ims = new Ims('stage', cache)
+  expect(ims.cache).toEqual(cache)
 })
 
 test('getTokenData', () => {
@@ -292,6 +314,195 @@ test('Ims.validateToken bad token', async () => {
       valid: false,
       reason: 'bad payload'
     })
+})
+
+test('Ims.validateToken bad token, with cache', async () => {
+  const cache = new ValidationCache(1, 2, 3)
+  const ims = new Ims('stage', cache)
+
+  const clientId = 'some-client-id'
+
+  await expect(ims.validateToken('BADTOKEN', clientId))
+    .resolves.toEqual({
+      valid: false,
+      reason: 'bad payload'
+    })
+})
+
+test('Ims._validateToken(token)', async () => {
+  const ims = new Ims()
+
+  const serverResponsePayload = {
+    valid: true,
+    token: {
+      as: 'ims-na1',
+      created_at: 100,
+      expires_in: 300,
+      access_token: 'my-access-token',
+      refresh_token: 'my-refresh-token',
+      type: 'access token',
+      client_id: 'some-client-id-1'
+    }
+  }
+
+  const serverResponse = {
+    status: 200,
+    text: () => serverResponsePayload
+  }
+
+  // have some return value from request module
+  mockExponentialBackoff.mockImplementationOnce(() => Promise.resolve(serverResponse))
+
+  const clientId = 'some-client-id-2'
+  const token = createTokenFromPayload(serverResponsePayload.token)
+
+  await expect(ims._validateToken(token, clientId))
+    .resolves.toEqual({
+      status: 200,
+      imsValidation: serverResponsePayload
+    })
+
+  expect(mockExponentialBackoff).toHaveBeenCalledTimes(1)
+})
+
+test('Ims.validateTokenAllowList(token, allowList)', async () => {
+  const ims = new Ims()
+
+  const serverResponsePayload = {
+    valid: true,
+    token: {
+      as: 'ims-na1',
+      created_at: 100,
+      expires_in: 300,
+      access_token: 'my-access-token',
+      refresh_token: 'my-refresh-token',
+      type: 'access token',
+      client_id: 'some-client-id-2'
+    }
+  }
+
+  const serverResponse = {
+    status: 200,
+    text: () => serverResponsePayload
+  }
+
+  // have some return value from request module
+  mockExponentialBackoff.mockImplementationOnce(() => Promise.resolve(serverResponse))
+
+  const clientId = 'some-client-id-2'
+  const token = createTokenFromPayload(serverResponsePayload.token)
+
+  await expect(ims.validateTokenAllowList(token, [clientId]))
+    .resolves.toEqual(serverResponsePayload)
+
+  expect(mockExponentialBackoff).toHaveBeenCalledTimes(1)
+})
+
+test('Ims.validateTokenAllowList(token, allowList) clientId not in allow list', async () => {
+  const ims = new Ims()
+
+  const serverResponsePayload = {
+    valid: true,
+    token: {
+      as: 'ims-na1',
+      created_at: 100,
+      expires_in: 300,
+      access_token: 'my-access-token',
+      refresh_token: 'my-refresh-token',
+      type: 'access token',
+      client_id: 'some-client-id-1'
+    }
+  }
+
+  const serverResponse = {
+    status: 200,
+    text: () => serverResponsePayload
+  }
+
+  // have some return value from request module
+  mockExponentialBackoff.mockImplementationOnce(() => Promise.resolve(serverResponse))
+
+  const clientId = 'some-client-id-2'
+  const token = createTokenFromPayload(serverResponsePayload.token)
+
+  await expect(ims.validateTokenAllowList(token, [clientId]))
+    .resolves.toEqual({
+      valid: false,
+      reason: 'Token is not valid, reason: IMS client is not authorized to call this endpoint. ' +
+      'Please use a JWT from an IMS client on the allow list.'
+    })
+
+  expect(mockExponentialBackoff).toHaveBeenCalledTimes(1)
+})
+
+test('Ims.validateTokenAllowList(token, allowList) clientId not in allow list, with cache', async () => {
+  const cache = new ValidationCache(1, 2, 3)
+  const ims = new Ims('stage', cache)
+
+  const serverResponsePayload = {
+    valid: true,
+    token: {
+      as: 'ims-na1',
+      created_at: 100,
+      expires_in: 300,
+      access_token: 'my-access-token',
+      refresh_token: 'my-refresh-token',
+      type: 'access token',
+      client_id: 'some-client-id-1'
+    }
+  }
+
+  const serverResponse = {
+    status: 200,
+    text: () => serverResponsePayload
+  }
+
+  // have some return value from request module
+  mockExponentialBackoff.mockImplementationOnce(() => Promise.resolve(serverResponse))
+
+  const clientId = 'some-client-id-2'
+  const token = createTokenFromPayload(serverResponsePayload.token)
+
+  await expect(ims.validateTokenAllowList(token, [clientId]))
+    .resolves.toEqual({
+      valid: false,
+      reason: 'Token is not valid, reason: IMS client is not authorized to call this endpoint. ' +
+      'Please use a JWT from an IMS client on the allow list.'
+    })
+
+  expect(mockExponentialBackoff).toHaveBeenCalledTimes(1)
+})
+
+test('Ims.validateTokenAllowList(token, allowList) clientId not in allow list, with cache, empty allow list', async () => {
+  const cache = new ValidationCache(1, 2, 3)
+  const ims = new Ims('stage', cache)
+
+  const serverResponsePayload = {
+    valid: true,
+    token: {
+      as: 'ims-na1',
+      created_at: 100,
+      expires_in: 300,
+      access_token: 'my-access-token',
+      refresh_token: 'my-refresh-token',
+      type: 'access token',
+      client_id: 'some-client-id-1'
+    }
+  }
+
+  const serverResponse = {
+    status: 200,
+    text: () => serverResponsePayload
+  }
+
+  // have some return value from request module
+  mockExponentialBackoff.mockImplementationOnce(() => Promise.resolve(serverResponse))
+  const token = createTokenFromPayload(serverResponsePayload.token)
+
+  await expect(ims.validateTokenAllowList(token))
+    .resolves.toEqual(serverResponsePayload)
+
+  expect(mockExponentialBackoff).toHaveBeenCalledTimes(1)
 })
 
 test('Ims.getOrganizations(token)', async () => {


### PR DESCRIPTION
## Description

This PR adds the validation caching functionality currently used by the shared validator actions. 

It also adds a new function that allows implementers to validate a token against an allow-list of IMS clients. 

This should not be breaking as the `validateToken` call should return the same data as before. The old `validateToken` function has been moved to a private function `_validateToken`, and has been slightly modified to work with ValidationCache. 

## Motivation and Context

To use in the App Builder Delete Service and allow others to cache validations / invalidations. To allow validating a token against an allow-list.

## How Has This Been Tested?

Ran `npm run test`, branch tested against Delete Service ims-auth PR

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
