### PR TITLE
fix: ims tests, replace restoreAllMocks with clearAllMocks

### DIFF
--- a/test/ims.test.js
+++ b/test/ims.test.js
@@ -56,7 +56,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  jest.restoreAllMocks()
+  jest.clearAllMocks()
   libEnv.getCliEnv.mockReturnValue(PROD_ENV) // default
   mockExponentialBackoff.mockClear()
 })


### PR DESCRIPTION
Fix test issues when trying to update Jest to 29+ 

See [this issue](https://github.com/adobe/aio-cli-plugin-app/issues/648) for further explanation 