### PR TITLE
fix: add env to cache key

### DIFF
--- a/src/ims.js
+++ b/src/ims.js
@@ -225,6 +225,7 @@ class Ims {
    * @param {ValidationCache} cache The cache instance to use.
    */
   constructor (env = getCliEnv(), cache) {
+    this.env = env
     this.endpoint = IMS_ENDPOINTS[env] || IMS_ENDPOINTS[DEFAULT_ENV]
     if (cache) {
       this.cache = cache
@@ -491,7 +492,7 @@ class Ims {
       return validationResponse
     }
 
-    const { imsValidation } = this.cache ? await this.cache.validateWithCache(validateAllowList, token, allowList) : await validateAllowList(token, allowList)
+    const { imsValidation } = this.cache ? await this.cache.validateWithCache(validateAllowList, token, allowList, this.env) : await validateAllowList(token, allowList)
     return imsValidation
   }
 
@@ -504,7 +505,7 @@ class Ims {
    */
   async validateToken (token, clientId) {
     aioLogger.debug('validateToken(%s, %s)', token, clientId)
-    const { imsValidation } = this.cache ? await this.cache.validateWithCache(this._validateToken, token, clientId) : await this._validateToken(token, clientId)
+    const { imsValidation } = this.cache ? await this.cache.validateWithCache(this._validateToken, token, clientId, this.env) : await this._validateToken(token, clientId)
     return imsValidation
   }
 

--- a/test/ValidationCache.test.js
+++ b/test/ValidationCache.test.js
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
If we don't do this, a token in one environment can technically still be valid in another