### PR TITLE
getAccessTokenByClientCredentials call failed as IMS Scopes were reset

### DIFF
--- a/src/ims.js
+++ b/src/ims.js
@@ -372,7 +372,7 @@ class Ims {
    *      {@link toTokenResult} or rejects to an error message.
    */
   async getAccessTokenByClientCredentials (clientId, clientSecret, orgId, scopes) {
-    aioLogger.debug('getAccessTokenByClientCredentials(%s, %s, %s, %o)', clientId, clientSecret, orgId, scopes = [])
+    aioLogger.debug('getAccessTokenByClientCredentials(%s, %s, %s, %o)', clientId, clientSecret, orgId, scopes || [])
 
     // prepare the data with common data
     const postData = {

--- a/src/ims.js
+++ b/src/ims.js
@@ -371,8 +371,8 @@ class Ims {
    * @returns {Promise} a promise resolving to a tokens object as described in the
    *      {@link toTokenResult} or rejects to an error message.
    */
-  async getAccessTokenByClientCredentials (clientId, clientSecret, orgId, scopes) {
-    aioLogger.debug('getAccessTokenByClientCredentials(%s, %s, %s, %o)', clientId, clientSecret, orgId, scopes || [])
+  async getAccessTokenByClientCredentials (clientId, clientSecret, orgId, scopes = []) {
+    aioLogger.debug('getAccessTokenByClientCredentials(%s, %s, %s, %o)', clientId, clientSecret, orgId, scopes)
 
     // prepare the data with common data
     const postData = {

--- a/test/ims.test.js
+++ b/test/ims.test.js
@@ -754,3 +754,27 @@ test('Ims.getAccessTokenByClientCredentials', async () => {
   await expect(ims.getAccessTokenByClientCredentials(clientId, clientSecret, orgId, scopes))
     .resolves.toEqual({ payload: serverResponsePayload })
 })
+
+test('Ims.getAccessTokenByClientCredentials - empty scopes', async () => {
+  const ims = new Ims()
+
+  const clientId = 'some-client-id'
+  const clientSecret = 'some-client-secret'
+  const orgId = 'some-org-id'
+  const scopes = undefined
+
+  const serverResponsePayload = {
+    access_token: ''
+  }
+
+  const res = {
+    status: 200,
+    text: () => Promise.resolve(serverResponsePayload)
+  }
+
+  // have some return value from request module
+  mockExponentialBackoff.mockImplementation(() => Promise.resolve(res))
+
+  await expect(ims.getAccessTokenByClientCredentials(clientId, clientSecret, orgId, scopes))
+    .resolves.toEqual({ payload: serverResponsePayload })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When trying to use getAccessTokenByClientCredentials for a garage-week project, I always got an error 400 returned.
After some debugging locally, I found out that the debug logging code is always resetting the scope variable.
Here a proposed fix.

## Related Issue

N/A

## Motivation and Context

Fix client credentials login

## How Has This Been Tested?

Tested locally by running the module inside NodeJS

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
