### PR TITLE
fix: update docs for getAccessTokenByClientCredentials, other docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ OAuth Server-to-Server (client credentials grant type) configuration requires th
 | client_secrets| An array of IMS (OAUth2) client secrets|
 | technical_account_email| The _Technical Account Email_ from the integration overview screen in the Adobe Developer Console|
 | technical_account_id| The _Technical Account ID_ from the integration overview screen in the Adobe Developer Console|
-| scopes| Scopes to assign to the tokens. This is an array of strings which depends on the services this integration is subscribed to. The list of scopes defined for the OAuth2 Server-to-Server credential is listed under the `Scopes` tab for the credential in Adobe Developer Console.| 
+| scopes| Scopes to assign to the tokens. This is an array of strings which depends on the services this integration is subscribed to. The list of scopes defined for the OAuth2 Server-to-Server credential is listed under the `Scopes` tab for the credential in Adobe Developer Console.|
 |ims_org_id|The Organization ID from the integration overview screen in the Adobe Developer Console.|
 
 ## Token Validation

--- a/src/ValidationCache.js
+++ b/src/ValidationCache.js
@@ -96,7 +96,7 @@ class ValidationCache {
 
   /**
    * @param {Array} params
-   * @returns
+   * @returns {string} the computed hash key
    * @memberof ValidationCache
    * @private
    */

--- a/src/ims.js
+++ b/src/ims.js
@@ -46,6 +46,13 @@ const CLIENT_SECRET = 'client_secret'
 const SCOPE = 'scope'
 
 /**
+ * @typedef {object} ClientCredentialsResponse
+ * @property {string} access_token The access token issued by IMS
+ * @property {string} token_type The type of the token (in this case 'bearer')
+ * @property {number} expires_in The lifetime in seconds of the access token
+ */
+
+/**
  * Send the request.
  *
  * @private
@@ -369,8 +376,8 @@ class Ims {
    * @param {string} clientSecret The Client Secret proving client ID ownership
    * @param {string} orgId the IMS org Id
    * @param {Array<string>} scopes The list of scopes to request as a blank separated list
-   * @returns {Promise} a promise resolving to a tokens object as described in the
-   *      {@link toTokenResult} or rejects to an error message.
+   * @returns {Promise} a promise resolving to a token object as described in the
+   *      {@link ClientCredentialsResponse} or rejects to an error message.
    */
   async getAccessTokenByClientCredentials (clientId, clientSecret, orgId, scopes = []) {
     aioLogger.debug('getAccessTokenByClientCredentials(%s, %s, %s, %o)', clientId, clientSecret, orgId, scopes)


### PR DESCRIPTION
## Motivation and Context

The new OAuth Server to Server credentials grant type call returns an expiry in seconds, not milliseconds, like the older API. This will clarify things in the docs.

Also, other doc warnings have been fixed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
