### PR TITLE
Issue #67 - access_token is stored in global conf not local .aio

### DIFF
--- a/src/ctx/ConfigCliContext.js
+++ b/src/ctx/ConfigCliContext.js
@@ -110,7 +110,10 @@ class ConfigCliContext extends Context {
   /** @private */
   getContextValueFromOptionalSource (key, source) {
     const fullKey = `${this.keyNames.IMS}.${this.keyNames.CONTEXTS}.${key}`
-    return source !== undefined ? this.aioConfig.get(fullKey, source) : this.aioConfig.get(fullKey)
+    return {
+      data: this.aioConfig.get(fullKey, source),
+      local: source === 'local' || (!source && !!this.aioConfig.get(fullKey, 'local'))
+    }
   }
 }
 

--- a/src/ctx/Context.js
+++ b/src/ctx/Context.js
@@ -51,6 +51,7 @@ class Context {
    *
    *   - `name`: The actual context name used
    *   - `data`: The IMS context data
+   *   - `local`: Whether the context data is stored locally or not
    *
    * @param {string} contextName Name of the context information to return.
    * @returns {Promise<object>} The configuration object
@@ -63,14 +64,16 @@ class Context {
     }
 
     if (contextName) {
+      const { data, local } = await this.getContextValue(contextName)
       return {
         name: contextName,
-        data: await this.getContextValue(contextName)
+        data,
+        local
       }
     }
 
     // missing context and no current context
-    return { name: contextName, data: undefined }
+    return { name: contextName, data: undefined, local: false }
   }
 
   /**
@@ -139,7 +142,7 @@ class Context {
 
   /**
    * @param {string} contextName context name
-   * @returns {Promise<any>} context value
+   * @returns {Promise<{data: any, local: boolean}>} context value
    * @protected
    * @ignore
    */

--- a/src/ctx/StateActionContext.js
+++ b/src/ctx/StateActionContext.js
@@ -58,7 +58,10 @@ class StateActionContext extends Context {
     aioLogger.debug('getContextValue(%s)', key)
     // on first run load the tokens from the cloud State
     await this.loadTokensOnce()
-    return cloneDeep(this.data[this.keyNames.CONTEXTS][key])
+    return {
+      data: cloneDeep(this.data[this.keyNames.CONTEXTS][key]),
+      local: false
+    }
   }
 
   /**


### PR DESCRIPTION
This change checks where an IMS context is defined, and stores the tokens in the same location (i.e. local or global).
Furthermore, on logout, _only_ the tokens are removed, rather than the entire IMS context being rewritten, as was the case previously. The context data is the merged view of global and local configs for a context, so rewriting it risks accidentally copying data between the local IMS context definition and the global one.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
