### PR TITLE
fix: validate token before validating against allow list

### DIFF
--- a/src/ims.js
+++ b/src/ims.js
@@ -481,12 +481,11 @@ class Ims {
       let validationResponse = await this._validateToken(token)
 
       // Validate token against the allow list
-      const tokenData = getTokenData(token)
-      const clientId = tokenData.client_id
-      if (allowList) {
+      if (validationResponse.imsValidation.valid && allowList) {
         aioLogger.debug('validateTokenAllowList (allowList): (%s)', allowList.join(', '))
+        const tokenData = getTokenData(token)
+        const clientId = tokenData.client_id
         if (allowList.indexOf(clientId) === -1) {
-          console.log(`${clientId} not in allow list: ${allowList.join(', ')}`)
           validationResponse = {
             status: 403,
             imsValidation: {

--- a/test/ims.test.js
+++ b/test/ims.test.js
@@ -505,6 +505,36 @@ test('Ims.validateTokenAllowList(token, allowList) clientId not in allow list, w
   expect(mockExponentialBackoff).toHaveBeenCalledTimes(1)
 })
 
+test('Ims.validateTokenAllowList(token, allowList) bad token, with cache', async () => {
+  const cache = new ValidationCache(1, 2, 3)
+  const ims = new Ims('stage', cache)
+  const clientId = 'some-client-id-2'
+  const token = 'fake'
+
+  await expect(ims.validateTokenAllowList(token, [clientId]))
+    .resolves.toEqual({
+      valid: false,
+      reason: 'bad payload'
+    })
+
+  expect(mockExponentialBackoff).toHaveBeenCalledTimes(0)
+})
+
+test('Ims.validateTokenAllowList(token, allowList) bad token in jwt format, with cache', async () => {
+  const cache = new ValidationCache(1, 2, 3)
+  const ims = new Ims('stage', cache)
+  const clientId = 'some-client-id-2'
+  const token = 'fake.fake'
+
+  await expect(ims.validateTokenAllowList(token, [clientId]))
+    .resolves.toEqual({
+      valid: false,
+      reason: 'bad payload'
+    })
+
+  expect(mockExponentialBackoff).toHaveBeenCalledTimes(0)
+})
+
 test('Ims.getOrganizations(token)', async () => {
   const ims = new Ims()
 


### PR DESCRIPTION
When passing a token like `Bearer fake` to `validateTokenAllowList()`, this error was popping up: 
```
{
	"error": "The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined"
}
```

And when passing a token like `Bearer fake.fake` to `validateTokenAllowList()`, this error was popping up: 
```
{
	"error": "Unexpected token '}', \"}�\" is not valid JSON"
}
```

We need to check the output of the validate token call before attempting to validate against a potential allow list. These cases should return a bad payload error